### PR TITLE
Replace binary assets with placeholders for offline site

### DIFF
--- a/my-offline-site/README.md
+++ b/my-offline-site/README.md
@@ -1,0 +1,60 @@
+# My Offline Site
+
+Ce dépôt contient un site web entièrement hors ligne explorant les enjeux de la sécurité des intelligences artificielles.
+
+## Fonctionnalités principales
+- **Progressive Web App** avec manifest et service worker en cache-first.
+- **25 pages de contenu** couvrant alignement, interprétabilité, gouvernance, résilience, etc.
+- **Animations CSS et JavaScript** (défilement, particules canvas) pour un rendu moderne et dynamique.
+- **Accessibilité et responsive design** inspiré d'une charte graphique sobre et élégante.
+- **Dépendances 100 % locales** : aucune ressource distante, aucune police externe.
+
+## Structure
+```
+my-offline-site/
+├─ index.html
+├─ README.md
+├─ manifest.json
+├─ service-worker.js
+├─ css/
+│  └─ styles.css
+├─ js/
+│  ├─ app.js
+│  └─ sw-register.js
+├─ assets/
+│  ├─ images/
+│  │  └─ hero.jpg.placeholder
+│  └─ icons/
+│     ├─ icon-192.png.placeholder
+│     └─ icon.svg
+└─ test/
+   └─ check_site.js
+```
+
+## Remplacer les placeholders binaires
+
+- `assets/images/hero.jpg.placeholder` → remplacez par votre visuel `hero.jpg` (même nom sans l'extension `.placeholder`).
+- `assets/icons/icon-192.png.placeholder` → remplacez par une icône carrée 192×192 `icon-192.png`.
+
+Supprimez les fichiers `.placeholder` après les avoir remplacés et, si nécessaire, ajustez les références dans `manifest.json` et `index.html`.
+
+## Lancer un serveur local
+
+Le service worker requiert un contexte sécurisé. Utilisez un serveur de développement simple :
+
+```bash
+cd my-offline-site
+python -m http.server 8000
+```
+
+Ensuite, ouvrez [http://localhost:8000](http://localhost:8000) dans votre navigateur. Après le premier chargement, le service worker mettra les ressources en cache pour une navigation hors connexion.
+
+## Tests
+Le script `test/check_site.js` vérifie que la page d'accueil répond correctement et contient la balise `meta` indiquant la compatibilité hors ligne. Exécutez :
+
+```bash
+node test/check_site.js
+```
+
+## Licence
+Projet mis à disposition sans licence spécifique. Utilisation libre.

--- a/my-offline-site/assets/icons/icon-192.png.placeholder
+++ b/my-offline-site/assets/icons/icon-192.png.placeholder
@@ -1,0 +1,1 @@
+remplacer par icon-192.png

--- a/my-offline-site/assets/icons/icon.svg
+++ b/my-offline-site/assets/icons/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#334155" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="40" fill="url(#grad)" />
+  <path d="M58 96c0-21 17-38 38-38s38 17 38 38-17 38-38 38-38-17-38-38zm38-52c-28.7 0-52 23.3-52 52s23.3 52 52 52 52-23.3 52-52-23.3-52-52-52zm0 32c11 0 20 9 20 20s-9 20-20 20-20-9-20-20 9-20 20-20z" fill="#f8fafc" fill-rule="evenodd" />
+</svg>

--- a/my-offline-site/assets/images/hero.jpg.placeholder
+++ b/my-offline-site/assets/images/hero.jpg.placeholder
@@ -1,0 +1,1 @@
+remplacer par hero.jpg

--- a/my-offline-site/css/styles.css
+++ b/my-offline-site/css/styles.css
@@ -1,0 +1,536 @@
+:root {
+    color-scheme: dark light;
+    --bg: #0b0b0f;
+    --bg-soft: #111119;
+    --bg-accent: #161623;
+    --fg: #f5f6fa;
+    --muted: #a3a6b5;
+    --accent: #4d8dff;
+    --accent-soft: rgba(77, 141, 255, 0.12);
+    --radius: 18px;
+    --shadow: 0 24px 60px rgba(6, 11, 30, 0.4);
+    --transition: 280ms cubic-bezier(0.4, 0, 0.2, 1);
+    font-family: "SF Pro Display", "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+
+* {
+    box-sizing: border-box;
+}
+
+body {
+    margin: 0;
+    background: radial-gradient(circle at top left, #12121f, #050507 60%);
+    color: var(--fg);
+    font-family: inherit;
+    line-height: 1.6;
+    min-height: 100vh;
+}
+
+img {
+    max-width: 100%;
+    display: block;
+    border-radius: var(--radius);
+}
+
+a {
+    color: inherit;
+    text-decoration: none;
+}
+
+a:focus,
+a:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 3px;
+}
+
+.skip-link {
+    position: absolute;
+    left: -999px;
+    top: auto;
+    width: 1px;
+    height: 1px;
+    overflow: hidden;
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    left: 50%;
+    top: 12px;
+    width: auto;
+    height: auto;
+    padding: 0.75rem 1.5rem;
+    background: var(--accent);
+    color: #020203;
+    border-radius: 999px;
+    transform: translateX(-50%);
+}
+
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 900;
+    backdrop-filter: blur(14px);
+    background: rgba(7, 8, 12, 0.8);
+    border-bottom: 1px solid rgba(255, 255, 255, 0.04);
+}
+
+.header.is-scrolled {
+    background: rgba(7, 8, 12, 0.92);
+    box-shadow: 0 18px 32px rgba(3, 4, 8, 0.35);
+}
+
+.header--compact {
+    position: static;
+    backdrop-filter: none;
+    background: transparent;
+    border-bottom: none;
+}
+
+.header__inner {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 1.25rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.logo {
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    font-size: 0.95rem;
+    color: var(--fg);
+}
+
+.nav {
+    position: relative;
+}
+
+.nav__toggle {
+    display: none;
+    background: var(--accent);
+    color: #050507;
+    border: none;
+    padding: 0.65rem 1.1rem;
+    border-radius: 999px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background var(--transition), transform var(--transition);
+}
+
+.nav__toggle:hover,
+.nav__toggle:focus-visible {
+    background: #70a7ff;
+}
+
+.nav__list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    gap: 1.5rem;
+    align-items: center;
+}
+
+.nav__list a {
+    position: relative;
+    font-size: 0.95rem;
+    font-weight: 500;
+    color: var(--muted);
+    transition: color var(--transition);
+}
+
+.nav__list a::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: -6px;
+    width: 100%;
+    height: 2px;
+    background: var(--accent);
+    transform: scaleX(0);
+    transform-origin: left;
+    transition: transform var(--transition);
+}
+
+.nav__list a:hover,
+.nav__list a:focus {
+    color: var(--fg);
+}
+
+.nav__list a:hover::after,
+.nav__list a:focus::after {
+    transform: scaleX(1);
+}
+
+.hero {
+    position: relative;
+    overflow: hidden;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2.5rem;
+    align-items: center;
+    padding: 6rem 1.5rem 4rem;
+    max-width: 1200px;
+    margin: 0 auto;
+}
+
+.hero::before {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 30% 20%, rgba(77, 141, 255, 0.35), transparent 60%);
+    opacity: 0.6;
+    pointer-events: none;
+}
+
+.hero__content {
+    position: relative;
+    z-index: 2;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.hero__kicker {
+    letter-spacing: 0.4em;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    color: var(--accent);
+}
+
+.hero__title {
+    font-size: clamp(2.5rem, 4vw + 1rem, 4rem);
+    line-height: 1.1;
+    margin: 0;
+    animation: fadeInUp 1.2s ease both;
+}
+
+.hero__subtitle {
+    max-width: 36ch;
+    color: var(--muted);
+    margin: 0;
+}
+
+.hero__visual {
+    position: relative;
+    width: clamp(240px, 28vw, 420px);
+    aspect-ratio: 1;
+    border-radius: 36px;
+    background: radial-gradient(circle at 25% 25%, rgba(94, 197, 255, 0.35), transparent 55%),
+        radial-gradient(circle at 75% 40%, rgba(77, 141, 255, 0.35), transparent 60%),
+        linear-gradient(145deg, rgba(15, 23, 42, 0.7), rgba(15, 23, 42, 0.1));
+    box-shadow: 0 40px 80px rgba(15, 23, 42, 0.35);
+    overflow: hidden;
+    z-index: 1;
+    animation: float 6s ease-in-out infinite;
+}
+
+.hero__visual-glow {
+    position: absolute;
+    inset: -20%;
+    background: conic-gradient(from 180deg at 50% 50%, rgba(94, 197, 255, 0.25), rgba(15, 23, 42, 0.05));
+    filter: blur(40px);
+    opacity: 0.8;
+    animation: pulse 8s ease-in-out infinite;
+}
+
+#particle-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    z-index: 1;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.85rem 1.8rem;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #4d8dff, #5ec5ff);
+    color: #041326;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    transition: transform var(--transition), box-shadow var(--transition);
+    box-shadow: var(--shadow);
+}
+
+.btn:hover,
+.btn:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 30px 60px rgba(77, 141, 255, 0.35);
+}
+
+.btn--ghost {
+    background: transparent;
+    color: var(--fg);
+    border: 1px solid rgba(255, 255, 255, 0.15);
+    box-shadow: none;
+}
+
+.section {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 4rem 1.5rem;
+    display: grid;
+    gap: 2rem;
+    position: relative;
+}
+
+.section--grid .topics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.section--accent {
+    background: var(--bg-accent);
+    border-radius: var(--radius);
+    margin-bottom: 4rem;
+    padding: 3.5rem;
+    box-shadow: var(--shadow);
+}
+
+.section__header {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.section__header h2 {
+    margin: 0;
+    font-size: clamp(1.75rem, 2vw + 1rem, 2.75rem);
+}
+
+.section__header p {
+    margin: 0;
+    color: var(--muted);
+}
+
+.topics-grid {
+    position: relative;
+    z-index: 2;
+}
+
+.topic-card {
+    background: rgba(255, 255, 255, 0.02);
+    border: 1px solid rgba(255, 255, 255, 0.06);
+    border-radius: var(--radius);
+    padding: 1.6rem;
+    display: grid;
+    gap: 0.75rem;
+    transition: border var(--transition), transform var(--transition), background var(--transition);
+}
+
+.topic-card:hover,
+.topic-card:focus-visible {
+    transform: translateY(-4px);
+    border-color: rgba(77, 141, 255, 0.8);
+    background: rgba(77, 141, 255, 0.12);
+}
+
+.timeline {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.5rem;
+}
+
+.timeline__item {
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: var(--radius);
+    padding: 1.75rem;
+    border: 1px solid rgba(255, 255, 255, 0.04);
+    position: relative;
+}
+
+.timeline__item h3 {
+    margin-top: 0;
+}
+
+.cta {
+    display: grid;
+    gap: 1.5rem;
+    align-items: start;
+}
+
+.footer {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: 2.5rem 1.5rem 4rem;
+    color: var(--muted);
+    text-align: center;
+    font-size: 0.9rem;
+}
+
+.page {
+    background: var(--bg);
+    min-height: 100vh;
+}
+
+.page__main {
+    max-width: 940px;
+    margin: 0 auto;
+    padding: 4.5rem 1.5rem 3.5rem;
+    display: grid;
+    gap: 3rem;
+}
+
+.page__intro h1 {
+    font-size: clamp(2rem, 3vw + 1rem, 3rem);
+    margin-bottom: 0.75rem;
+}
+
+.page__intro p {
+    color: var(--muted);
+    margin: 0;
+}
+
+.page__grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.detail-card {
+    background: rgba(255, 255, 255, 0.02);
+    border-radius: var(--radius);
+    border: 1px solid rgba(255, 255, 255, 0.05);
+    padding: 1.75rem;
+    transition: transform var(--transition), border var(--transition);
+}
+
+.detail-card:hover,
+.detail-card:focus-within {
+    transform: translateY(-4px);
+    border-color: rgba(77, 141, 255, 0.45);
+}
+
+.page__callout {
+    background: rgba(77, 141, 255, 0.12);
+    border-radius: var(--radius);
+    padding: 2.25rem;
+    border: 1px solid rgba(77, 141, 255, 0.35);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.page__callout ul {
+    margin: 0;
+    padding-left: 1.2rem;
+    color: var(--muted);
+}
+
+.page__callout a {
+    color: var(--fg);
+    text-decoration: underline;
+}
+
+.reveal {
+    opacity: 0;
+    transform: translateY(40px);
+}
+
+.reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+    transition: opacity 700ms ease, transform 700ms ease;
+}
+
+@keyframes fadeInUp {
+    from {
+        opacity: 0;
+        transform: translateY(40px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+@keyframes float {
+    0%, 100% {
+        transform: translateY(0);
+    }
+    50% {
+        transform: translateY(-10px);
+    }
+}
+
+@keyframes pulse {
+    0%,
+    100% {
+        transform: scale(1);
+        opacity: 0.7;
+    }
+    50% {
+        transform: scale(1.05);
+        opacity: 1;
+    }
+}
+
+@media (max-width: 768px) {
+    .nav__toggle {
+        display: inline-flex;
+    }
+
+    .nav__list {
+        position: absolute;
+        top: calc(100% + 12px);
+        right: 0;
+        flex-direction: column;
+        background: rgba(12, 13, 20, 0.95);
+        padding: 1rem 1.2rem;
+        border-radius: var(--radius);
+        box-shadow: var(--shadow);
+        min-width: 220px;
+        transform: scale(0.95);
+        opacity: 0;
+        pointer-events: none;
+        transition: opacity var(--transition), transform var(--transition);
+    }
+
+    .nav__list.is-open {
+        opacity: 1;
+        pointer-events: auto;
+        transform: scale(1);
+    }
+
+    .nav__list li {
+        width: 100%;
+    }
+
+    .nav__list a {
+        display: block;
+        padding: 0.6rem 0.4rem;
+    }
+
+    .hero {
+        padding-top: 5rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *, *::before, *::after {
+        animation-duration: 0.01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 0.01ms !important;
+        scroll-behavior: auto !important;
+    }
+}
+
+.sw-error {
+    position: fixed;
+    bottom: 1.5rem;
+    left: 50%;
+    transform: translateX(-50%);
+    background: #ff5f5f;
+    color: #090909;
+    padding: 1rem 1.5rem;
+    border-radius: 999px;
+    box-shadow: var(--shadow);
+    font-weight: 600;
+    z-index: 1000;
+}

--- a/my-offline-site/index.html
+++ b/my-offline-site/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Exploration complète des enjeux de sécurité des intelligences artificielles.">
+    <meta name="offline-ready" content="true">
+    <title>SafeIntelligence – Sécurité des IA</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" type="image/svg+xml" href="assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <link rel="stylesheet" href="css/styles.css">
+    <script defer src="js/app.js"></script>
+    <script defer src="js/sw-register.js"></script>
+</head>
+<body>
+    <a class="skip-link" href="#main">Passer au contenu</a>
+    <header class="header">
+        <div class="header__inner">
+            <a class="logo" href="index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="pages/alignment.html">Alignement</a></li>
+                    <li><a href="pages/interpretability.html">Interprétabilité</a></li>
+                    <li><a href="pages/governance.html">Gouvernance</a></li>
+                    <li><a href="pages/red-teaming.html">Red Teaming</a></li>
+                    <li><a href="pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <main id="main">
+        <section class="hero">
+            <canvas id="particle-canvas" aria-hidden="true"></canvas>
+            <div class="hero__content">
+                <p class="hero__kicker">Sécurité des intelligences artificielles</p>
+                <h1 class="hero__title">Anticipez les dérives, protégez vos systèmes.</h1>
+                <p class="hero__subtitle">Une expérience hors ligne, élégante et exhaustive pour maîtriser les risques de vos IA.</p>
+                <a class="btn" href="#sections">Explorer</a>
+            </div>
+            <div class="hero__visual" aria-hidden="true">
+                <div class="hero__visual-glow"></div>
+            </div>
+        </section>
+
+        <section class="section section--grid reveal" id="sections" aria-labelledby="overview-title">
+            <div class="section__header">
+                <h2 id="overview-title">Un panorama complet des risques</h2>
+                <p>Découvrez 24 domaines clés pour renforcer la sécurité de vos systèmes d'intelligence artificielle.</p>
+            </div>
+            <div class="topics-grid" role="list">
+                <a class="topic-card" role="listitem" href="pages/alignment.html">
+                    <h3>Alignement</h3>
+                    <p>Encadrez les objectifs des modèles pour qu'ils respectent vos contraintes.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/interpretability.html">
+                    <h3>Interprétabilité</h3>
+                    <p>Rendez vos modèles lisibles, auditables et dignes de confiance.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/scheming.html">
+                    <h3>Comportements stratégiques</h3>
+                    <p>Identifiez les actions opportunistes et prévoyez des garde-fous.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/robustness.html">
+                    <h3>Robustesse</h3>
+                    <p>Résistez aux perturbations et attaques adversariales.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/dataset-security.html">
+                    <h3>Sécurité des jeux de données</h3>
+                    <p>Protégez les données critiques contre la corruption et l'exfiltration.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/oversight.html">
+                    <h3>Supervision humaine</h3>
+                    <p>Impliquez l'humain dans les décisions cruciales avec des workflows efficaces.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/governance.html">
+                    <h3>Gouvernance</h3>
+                    <p>Structurez la responsabilité, la conformité et la transparence.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/threat-modeling.html">
+                    <h3>Modélisation des menaces</h3>
+                    <p>Anticipez les scénarios critiques pour mieux prioriser vos défenses.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/auditing.html">
+                    <h3>Audit des systèmes</h3>
+                    <p>Pilotez les vérifications régulières de vos pipelines IA.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/transparency.html">
+                    <h3>Transparence</h3>
+                    <p>Communiquez les risques sans compromettre la sécurité.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/monitoring.html">
+                    <h3>Surveillance continue</h3>
+                    <p>Détectez en temps réel les dérives comportementales.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/incident-response.html">
+                    <h3>Réponse aux incidents</h3>
+                    <p>Préparez vos équipes à intervenir rapidement et efficacement.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/adversarial-learning.html">
+                    <h3>Apprentissage adversarial</h3>
+                    <p>Renforcez vos modèles grâce à des scénarios d'attaque simulés.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/differential-privacy.html">
+                    <h3>Confidentialité différentielle</h3>
+                    <p>Garantissez la protection des données sensibles.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/secure-architecture.html">
+                    <h3>Architecture sécurisée</h3>
+                    <p>Concevez des pipelines fiables de bout en bout.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/human-in-the-loop.html">
+                    <h3>Humain dans la boucle</h3>
+                    <p>Combinez le jugement humain et la performance machine.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/policy.html">
+                    <h3>Politiques internes</h3>
+                    <p>Institutionnalisez la culture de sécurité IA.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/evaluation.html">
+                    <h3>Évaluations de sécurité</h3>
+                    <p>Mesurez la maturité de vos dispositifs de protection.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/red-teaming.html">
+                    <h3>Red Teaming IA</h3>
+                    <p>Débusquez les failles avant les attaquants.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/ethics.html">
+                    <h3>Éthique et sécurité</h3>
+                    <p>Harmonisez objectifs responsables et impératifs de sûreté.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/supply-chain.html">
+                    <h3>Chaîne d'approvisionnement</h3>
+                    <p>Sécurisez vos dépendances logicielles et matérielles.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/hardware-security.html">
+                    <h3>Sécurité matérielle</h3>
+                    <p>Protégez les composants critiques et contrôlez les accès.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/fail-safes.html">
+                    <h3>Mécanismes de repli</h3>
+                    <p>Préparez des plans de contingence et des arrêts maîtrisés.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/regulation.html">
+                    <h3>Régulation</h3>
+                    <p>Anticipez les nouvelles obligations internationales.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/contact.html">
+                    <h3>Contact</h3>
+                    <p>Collaborez avec notre équipe sécurité dédiée.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="section reveal" aria-labelledby="method-title">
+            <div class="section__header">
+                <h2 id="method-title">Méthodologie intégrée</h2>
+                <p>Une feuille de route structurée pour transformer vos engagements de sécurité en actions concrètes.</p>
+            </div>
+            <div class="timeline" role="list">
+                <article class="timeline__item" role="listitem">
+                    <h3>1. Diagnostic</h3>
+                    <p>Évaluez votre posture actuelle grâce à nos checklists interactives et grilles de maturité.</p>
+                </article>
+                <article class="timeline__item" role="listitem">
+                    <h3>2. Expérimentation</h3>
+                    <p>Priorisez les tests, red teamings et évaluations selon vos cas d'usage critiques.</p>
+                </article>
+                <article class="timeline__item" role="listitem">
+                    <h3>3. Déploiement</h3>
+                    <p>Installez des contrôles continus, automatisez les alertes et formez les équipes.</p>
+                </article>
+            </div>
+        </section>
+
+        <section class="section section--accent reveal" aria-labelledby="pwa-title">
+            <div class="section__header">
+                <h2 id="pwa-title">Une PWA conçue pour l'offline</h2>
+                <p>Installez l'application, profitez d'un chargement instantané et continuez vos explorations sans connexion.</p>
+            </div>
+            <div class="cta">
+                <p>L'icône de l'application apparaîtra dans votre lanceur après installation. Aucun suivi, aucune ressource distante.</p>
+                <a class="btn btn--ghost" href="manifest.json" download>Voir le manifest</a>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Conçu pour l'exploration hors ligne de la sécurité des IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/js/app.js
+++ b/my-offline-site/js/app.js
@@ -1,0 +1,139 @@
+(() => {
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const toggle = document.querySelector('.nav__toggle');
+    const list = document.querySelector('.nav__list');
+    if (toggle && list) {
+        toggle.addEventListener('click', () => {
+            const isOpen = list.classList.toggle('is-open');
+            toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+
+        list.addEventListener('click', (event) => {
+            if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+                list.classList.remove('is-open');
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+
+    const header = document.querySelector('.header');
+    if (header) {
+        const updateHeader = () => {
+            if (window.scrollY > 24) {
+                header.classList.add('is-scrolled');
+            } else {
+                header.classList.remove('is-scrolled');
+            }
+        };
+        window.addEventListener('scroll', updateHeader, { passive: true });
+        updateHeader();
+    }
+
+    const revealElements = document.querySelectorAll('.reveal');
+    if (revealElements.length) {
+        const onIntersect = (entries, observer) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        };
+        if (!prefersReducedMotion && 'IntersectionObserver' in window) {
+            const observer = new IntersectionObserver(onIntersect, {
+                rootMargin: '0px 0px -10%',
+                threshold: 0.15,
+            });
+            revealElements.forEach((el) => observer.observe(el));
+        } else {
+            revealElements.forEach((el) => el.classList.add('is-visible'));
+        }
+    }
+
+    const canvas = document.getElementById('particle-canvas');
+    if (canvas && canvas instanceof HTMLCanvasElement && !prefersReducedMotion) {
+        const context = canvas.getContext('2d');
+        if (context) {
+            const particles = [];
+            const particleCount = 80;
+            const color = 'rgba(77, 141, 255, 0.6)';
+
+            const resize = () => {
+                canvas.width = canvas.clientWidth;
+                canvas.height = canvas.clientHeight;
+            };
+            resize();
+            window.addEventListener('resize', resize);
+
+            for (let i = 0; i < particleCount; i += 1) {
+                particles.push({
+                    x: Math.random() * canvas.width,
+                    y: Math.random() * canvas.height,
+                    radius: Math.random() * 2 + 0.5,
+                    velocityX: (Math.random() - 0.5) * 0.4,
+                    velocityY: (Math.random() - 0.5) * 0.4,
+                });
+            }
+
+            const draw = () => {
+                context.clearRect(0, 0, canvas.width, canvas.height);
+                particles.forEach((particle) => {
+                    context.beginPath();
+                    context.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+                    context.fillStyle = color;
+                    context.fill();
+                });
+            };
+
+            const update = () => {
+                particles.forEach((particle) => {
+                    particle.x += particle.velocityX;
+                    particle.y += particle.velocityY;
+
+                    if (particle.x < 0 || particle.x > canvas.width) {
+                        particle.velocityX *= -1;
+                    }
+                    if (particle.y < 0 || particle.y > canvas.height) {
+                        particle.velocityY *= -1;
+                    }
+                });
+            };
+
+            const connect = () => {
+                for (let i = 0; i < particles.length; i += 1) {
+                    for (let j = i + 1; j < particles.length; j += 1) {
+                        const dx = particles[i].x - particles[j].x;
+                        const dy = particles[i].y - particles[j].y;
+                        const distance = Math.sqrt(dx * dx + dy * dy);
+                        if (distance < 140) {
+                            context.strokeStyle = `rgba(77, 141, 255, ${0.4 - distance / 360})`;
+                            context.lineWidth = 0.6;
+                            context.beginPath();
+                            context.moveTo(particles[i].x, particles[i].y);
+                            context.lineTo(particles[j].x, particles[j].y);
+                            context.stroke();
+                        }
+                    }
+                }
+            };
+
+            let animationId;
+            const animate = () => {
+                update();
+                draw();
+                connect();
+                animationId = window.requestAnimationFrame(animate);
+            };
+            animate();
+
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) {
+                    window.cancelAnimationFrame(animationId);
+                } else {
+                    animationId = window.requestAnimationFrame(animate);
+                }
+            });
+        }
+    }
+})();

--- a/my-offline-site/js/sw-register.js
+++ b/my-offline-site/js/sw-register.js
@@ -1,0 +1,22 @@
+(() => {
+    if (!('serviceWorker' in navigator)) {
+        console.warn('Service worker non pris en charge.');
+        return;
+    }
+
+    window.addEventListener('load', () => {
+        navigator.serviceWorker
+            .register('service-worker.js')
+            .then((registration) => {
+                console.info('Service worker enregistré.', registration.scope);
+            })
+            .catch((error) => {
+                console.error('Échec de l\'enregistrement du service worker :', error);
+                const announcement = document.createElement('div');
+                announcement.className = 'sw-error';
+                announcement.setAttribute('role', 'status');
+                announcement.textContent = 'Mode hors ligne indisponible. Veuillez vérifier votre navigateur.';
+                document.body.append(announcement);
+            });
+    });
+})();

--- a/my-offline-site/manifest.json
+++ b/my-offline-site/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "SafeIntelligence Offline",
+  "short_name": "SafeIntelligence",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#050507",
+  "theme_color": "#0a0a0a",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "assets/icons/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/my-offline-site/pages/adversarial-learning.html
+++ b/my-offline-site/pages/adversarial-learning.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Utiliser l'adversarial training pour fortifier les modèles.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Apprentissage adversarial – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Apprentissage adversarial</h1>
+            <p>Utiliser l'adversarial training pour fortifier les modèles.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/alignment.html
+++ b/my-offline-site/pages/alignment.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Explorer les techniques pour aligner les objectifs des systèmes intelligents sur les valeurs humaines.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Alignement des IA – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Alignement des IA</h1>
+            <p>Explorer les techniques pour aligner les objectifs des systèmes intelligents sur les valeurs humaines.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/auditing.html
+++ b/my-offline-site/pages/auditing.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Évaluer régulièrement la conformité et la sécurité des modèles.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Audit des systèmes – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Audit des systèmes</h1>
+            <p>Évaluer régulièrement la conformité et la sécurité des modèles.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/contact.html
+++ b/my-offline-site/pages/contact.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Entrer en relation avec l'équipe sécurité pour partager retours et besoins.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Contact et collaboration – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Contact et collaboration</h1>
+            <p>Entrer en relation avec l'équipe sécurité pour partager retours et besoins.</p>
+        </section>
+        <section class="page__grid" aria-label="Moyens de contact">
+            <article class="detail-card">
+                <h3>Prendre rendez-vous</h3>
+                <p>Planifiez une session d'évaluation conjointe avec nos experts sécurité et votre équipe produit.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Partage de rapports</h3>
+                <p>Envoyez vos rapports d'incidents ou vos audits pour bénéficier d'une revue croisée.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Communauté</h3>
+                <p>Rejoignez notre réseau de praticiens pour échanger des retours d'expérience et des bonnes pratiques.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Informations pratiques</h2>
+            <ul>
+                <li>Email : <a href="mailto:contact@safeintelligence.local">contact@safeintelligence.local</a></li>
+                <li>Téléphone : +33 1 23 45 67 89</li>
+                <li>Adresse : 42 Avenue de la Sûreté, 75000 Paris</li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/dataset-security.html
+++ b/my-offline-site/pages/dataset-security.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Protéger l'intégrité et la confidentialité des données d'entraînement.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Sécurité des jeux de données – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Sécurité des jeux de données</h1>
+            <p>Protéger l'intégrité et la confidentialité des données d'entraînement.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/differential-privacy.html
+++ b/my-offline-site/pages/differential-privacy.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Intégrer des garanties mathématiques de confidentialité.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Confidentialité différentielle – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Confidentialité différentielle</h1>
+            <p>Intégrer des garanties mathématiques de confidentialité.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/ethics.html
+++ b/my-offline-site/pages/ethics.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Aligner les considérations éthiques et sécuritaires.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Éthique et sécurité – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Éthique et sécurité</h1>
+            <p>Aligner les considérations éthiques et sécuritaires.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/evaluation.html
+++ b/my-offline-site/pages/evaluation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Tester systématiquement les modèles avant déploiement.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Évaluations de sécurité – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Évaluations de sécurité</h1>
+            <p>Tester systématiquement les modèles avant déploiement.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/fail-safes.html
+++ b/my-offline-site/pages/fail-safes.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Prévoir des arrêts d'urgence et limitations automatiques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Mécanismes de repli – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Mécanismes de repli</h1>
+            <p>Prévoir des arrêts d'urgence et limitations automatiques.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/governance.html
+++ b/my-offline-site/pages/governance.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Structurer des cadres de gouvernance adaptés aux risques des IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Gouvernance – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Gouvernance</h1>
+            <p>Structurer des cadres de gouvernance adaptés aux risques des IA.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/hardware-security.html
+++ b/my-offline-site/pages/hardware-security.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Protéger les accélérateurs et équipements critiques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Sécurité matérielle – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Sécurité matérielle</h1>
+            <p>Protéger les accélérateurs et équipements critiques.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/human-in-the-loop.html
+++ b/my-offline-site/pages/human-in-the-loop.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Associer les experts humains aux décisions critiques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Humain dans la boucle – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Humain dans la boucle</h1>
+            <p>Associer les experts humains aux décisions critiques.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/incident-response.html
+++ b/my-offline-site/pages/incident-response.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Préparer et orchestrer des plans de réponse aux crises.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Réponse aux incidents – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Réponse aux incidents</h1>
+            <p>Préparer et orchestrer des plans de réponse aux crises.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/interpretability.html
+++ b/my-offline-site/pages/interpretability.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Comprendre comment rendre les modèles transparents et explicables.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Interprétabilité – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Interprétabilité</h1>
+            <p>Comprendre comment rendre les modèles transparents et explicables.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/monitoring.html
+++ b/my-offline-site/pages/monitoring.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Mettre en place des capteurs pour détecter les dérives en production.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Surveillance continue – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Surveillance continue</h1>
+            <p>Mettre en place des capteurs pour détecter les dérives en production.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/oversight.html
+++ b/my-offline-site/pages/oversight.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Mettre en place des boucles de supervision efficaces et responsables.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Supervision humaine – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Supervision humaine</h1>
+            <p>Mettre en place des boucles de supervision efficaces et responsables.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/policy.html
+++ b/my-offline-site/pages/policy.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Développer des politiques et processus centrés sécurité.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Politiques internes – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Politiques internes</h1>
+            <p>Développer des politiques et processus centrés sécurité.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/red-teaming.html
+++ b/my-offline-site/pages/red-teaming.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Simuler des attaques réalistes pour renforcer la défense.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Red Teaming IA – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Red Teaming IA</h1>
+            <p>Simuler des attaques réalistes pour renforcer la défense.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/regulation.html
+++ b/my-offline-site/pages/regulation.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Naviguer dans les cadres réglementaires émergents.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Régulation – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Régulation</h1>
+            <p>Naviguer dans les cadres réglementaires émergents.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/robustness.html
+++ b/my-offline-site/pages/robustness.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Renforcer la résilience des modèles face aux perturbations et aux attaques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Robustesse – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Robustesse</h1>
+            <p>Renforcer la résilience des modèles face aux perturbations et aux attaques.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/scheming.html
+++ b/my-offline-site/pages/scheming.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Identifier et contrer les comportements opportunistes des IA avancées.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Comportements stratégiques – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Comportements stratégiques</h1>
+            <p>Identifier et contrer les comportements opportunistes des IA avancées.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/secure-architecture.html
+++ b/my-offline-site/pages/secure-architecture.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Concevoir des pipelines et infrastructures résilientes.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Architecture sécurisée – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Architecture sécurisée</h1>
+            <p>Concevoir des pipelines et infrastructures résilientes.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/supply-chain.html
+++ b/my-offline-site/pages/supply-chain.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Sécuriser les dépendances logicielles et matérielles.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Chaîne d'approvisionnement – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Chaîne d'approvisionnement</h1>
+            <p>Sécuriser les dépendances logicielles et matérielles.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/threat-modeling.html
+++ b/my-offline-site/pages/threat-modeling.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cartographier les scénarios d'attaque et les vulnérabilités.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Modélisation des menaces – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Modélisation des menaces</h1>
+            <p>Cartographier les scénarios d'attaque et les vulnérabilités.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/transparency.html
+++ b/my-offline-site/pages/transparency.html
@@ -1,0 +1,66 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Partager les informations critiques tout en préservant la sécurité.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#0a0a0a">
+    <title>Transparence – Sécurité des IA</title>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact">
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+    <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+    <ul class="nav__list" id="nav-list">
+        <li><a href="../index.html">Accueil</a></li>
+        <li><a href="../pages/alignment.html">Alignement</a></li>
+        <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+        <li><a href="../pages/governance.html">Gouvernance</a></li>
+        <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+        <li><a href="../pages/contact.html">Contact</a></li>
+    </ul>
+</nav>
+        </div>
+    </header>
+    <main id="content" class="page__main reveal">
+        <section class="page__intro">
+            <h1>Transparence</h1>
+            <p>Partager les informations critiques tout en préservant la sécurité.</p>
+        </section>
+        <section class="page__grid" aria-label="Détails">
+            <article class="detail-card">
+                <h3>Enjeux</h3>
+                <p>Identifier les risques majeurs et leurs impacts sur la sûreté de vos solutions.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Approches</h3>
+                <p>Déployer les leviers opérationnels, outils et cadres méthodologiques adaptés.</p>
+            </article>
+            <article class="detail-card">
+                <h3>Indicateurs</h3>
+                <p>Mesurer l'efficacité des contrôles à l'aide de métriques partagées et auditées.</p>
+            </article>
+        </section>
+        <section class="page__callout">
+            <h2>Ressources associées</h2>
+            <ul>
+                <li><a href="../pages/monitoring.html">Surveillance continue</a></li>
+                <li><a href="../pages/evaluation.html">Évaluations de sécurité</a></li>
+                <li><a href="../pages/policy.html">Politiques internes</a></li>
+            </ul>
+        </section>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Prévention des risques IA.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/service-worker.js
+++ b/my-offline-site/service-worker.js
@@ -1,0 +1,71 @@
+const CACHE_NAME = 'safeintelligence-v1';
+const ASSETS = [
+    './',
+    './assets/icons/icon.svg',
+    './css/styles.css',
+    './index.html',
+    './js/app.js',
+    './js/sw-register.js',
+    './manifest.json',
+    './pages/adversarial-learning.html',
+    './pages/alignment.html',
+    './pages/auditing.html',
+    './pages/contact.html',
+    './pages/dataset-security.html',
+    './pages/differential-privacy.html',
+    './pages/ethics.html',
+    './pages/evaluation.html',
+    './pages/fail-safes.html',
+    './pages/governance.html',
+    './pages/hardware-security.html',
+    './pages/human-in-the-loop.html',
+    './pages/incident-response.html',
+    './pages/interpretability.html',
+    './pages/monitoring.html',
+    './pages/oversight.html',
+    './pages/policy.html',
+    './pages/red-teaming.html',
+    './pages/regulation.html',
+    './pages/robustness.html',
+    './pages/scheming.html',
+    './pages/secure-architecture.html',
+    './pages/supply-chain.html',
+    './pages/threat-modeling.html',
+    './pages/transparency.html'
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys().then((keys) => Promise.all(
+            keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+        ))
+    );
+    self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+    if (request.method !== 'GET') {
+        return;
+    }
+
+    event.respondWith(
+        caches.match(request).then((cachedResponse) => {
+            if (cachedResponse) {
+                return cachedResponse;
+            }
+            return fetch(request).then((networkResponse) => {
+                const cloned = networkResponse.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+                return networkResponse;
+            }).catch(() => caches.match('./index.html'));
+        })
+    );
+});

--- a/my-offline-site/test/check_site.js
+++ b/my-offline-site/test/check_site.js
@@ -1,0 +1,55 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const port = 8123;
+
+const server = http.createServer((req, res) => {
+  const requestPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(rootDir, requestPath);
+
+  fs.readFile(filePath, (error, data) => {
+    if (error) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = ext === '.html' ? 'text/html; charset=utf-8' :
+      ext === '.css' ? 'text/css; charset=utf-8' :
+      ext === '.js' ? 'application/javascript; charset=utf-8' :
+      'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  http.get(`http://127.0.0.1:${port}/index.html`, (response) => {
+    const { statusCode } = response;
+    if (statusCode !== 200) {
+      console.error(`Échec: statut ${statusCode}`);
+      server.close(() => process.exit(1));
+      return;
+    }
+    let body = '';
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+    response.on('end', () => {
+      const hasMeta = body.includes('<meta name="offline-ready" content="true"');
+      if (!hasMeta) {
+        console.error('La balise <meta name="offline-ready" content="true"> est absente.');
+        server.close(() => process.exit(1));
+        return;
+      }
+      console.log('Test réussi: index.html répond et contient la balise meta offline-ready.');
+      server.close(() => process.exit(0));
+    });
+  }).on('error', (error) => {
+    console.error('Erreur de requête HTTP:', error);
+    server.close(() => process.exit(1));
+  });
+});


### PR DESCRIPTION
## Summary
- remove binary hero and icon assets and add text placeholders alongside a vector favicon
- refresh the hero area styling to rely on gradients instead of the removed bitmap artwork
- document placeholder replacement and local server usage while pointing the manifest and pages to the SVG icon

## Testing
- `node my-offline-site/test/check_site.js`


------
https://chatgpt.com/codex/tasks/task_e_68dbc753c8d4832b9267ef0c88a0829b