### PR TITLE
Refine offline IA site design with dynamic content

### DIFF
--- a/generated/codex-site-20250930/README.md
+++ b/generated/codex-site-20250930/README.md
@@ -1,0 +1,115 @@
+# SafeIntelligence – snapshot 2025-09-30
+
+Ce dossier contient une version entièrement hors ligne d'un site web consacré à la sécurité des intelligences artificielles. L'ensemble des fichiers (HTML, CSS, JS, manifest, service worker, tests et placeholders) est prêt à être copié tel quel dans un dépôt Git.
+
+## Fonctionnalités principales
+- **Progressive Web App** avec manifest et service worker en stratégie cache-first.
+- **25 pages thématiques** couvrant alignement, interprétabilité, red teaming, gouvernance, etc.
+- **Animations CSS et JavaScript** : transitions glassmorphism, effets de défilement, particules canvas et interactions accessibles.
+- **Illustrations génératives** : chaque page et la galerie d'accueil utilisent un canvas procédural et des palettes définies localement.
+- **Aucune dépendance distante** : aucune ressource CDN ou police externe, tout fonctionne hors connexion.
+
+## Structure
+```
+generated/codex-site-20250930/
+├─ index.html
+├─ README.md
+├─ manifest.json
+├─ service-worker.js
+├─ css/
+│  └─ styles.css
+├─ js/
+│  ├─ app.js
+│  ├─ page-data.js
+│  └─ sw-register.js
+├─ assets/
+│  ├─ images/
+│  │  └─ hero.jpg.placeholder
+│  └─ icons/
+│     ├─ icon-192.png.placeholder
+│     └─ icon.svg
+├─ pages/
+│  ├─ alignment.html
+│  ├─ adversarial-learning.html
+│  ├─ auditing.html
+│  ├─ contact.html
+│  ├─ dataset-security.html
+│  ├─ differential-privacy.html
+│  ├─ ethics.html
+│  ├─ evaluation.html
+│  ├─ fail-safes.html
+│  ├─ governance.html
+│  ├─ hardware-security.html
+│  ├─ human-in-the-loop.html
+│  ├─ incident-response.html
+│  ├─ interpretability.html
+│  ├─ monitoring.html
+│  ├─ oversight.html
+│  ├─ policy.html
+│  ├─ red-teaming.html
+│  ├─ regulation.html
+│  ├─ robustness.html
+│  ├─ scheming.html
+│  ├─ secure-architecture.html
+│  ├─ supply-chain.html
+│  ├─ threat-modeling.html
+│  └─ transparency.html
+└─ test/
+   └─ check_site.js
+```
+
+## Personnaliser les contenus
+Les textes, timelines, checklists et palettes d'illustrations sont centralisés dans `js/page-data.js`. Modifiez ce fichier pour adapter les contenus, les couleurs ou les accroches. Les pages consomment ces données dynamiquement à l'affichage.
+
+## Remplacer les placeholders binaires
+- `assets/images/hero.jpg.placeholder` → remplacez par votre visuel `hero.jpg` (même nom, sans l'extension `.placeholder`).
+- `assets/icons/icon-192.png.placeholder` → remplacez par une icône carrée 192×192 `icon-192.png`.
+
+Supprimez les fichiers `.placeholder` une fois vos médias en place et ajustez, si nécessaire, les références dans `manifest.json` et `index.html`.
+
+## Lancer un serveur local
+Le service worker requiert un contexte sécurisé. Utilisez un serveur de développement simple :
+
+```bash
+cd generated/codex-site-20250930
+python -m http.server 8000
+```
+
+Ensuite, ouvrez [http://localhost:8000](http://localhost:8000) dans votre navigateur. Après le premier chargement, le service worker mettra les ressources en cache pour une navigation hors connexion.
+
+## Tests
+Le script `test/check_site.js` vérifie que la page d'accueil répond correctement et contient la balise `meta` indiquant la compatibilité hors ligne. Exécutez :
+
+```bash
+cd generated/codex-site-20250930
+node test/check_site.js
+```
+
+## Intégration Git – branche `main`
+Pour intégrer ce dossier dans votre branche locale `main` :
+
+```bash
+git checkout main
+git pull
+cp -R generated/codex-site-20250930 <chemin-destination>
+cd <racine-du-dépôt>
+git add generated/codex-site-20250930
+git commit -m "Add offline IA security site snapshot 20250930"
+git push origin main
+```
+
+Adaptez `<chemin-destination>` et `<racine-du-dépôt>` à votre environnement si vous déplacez les fichiers.
+
+## Création d'une PR depuis `codex-site-fresh-20250930`
+Si vous préférez ouvrir une Pull Request :
+
+```bash
+git checkout -b codex-site-fresh-20250930
+git add generated/codex-site-20250930
+git commit -m "Add offline IA security site snapshot 20250930"
+git push origin codex-site-fresh-20250930
+# puis créez la PR (ex. via GitHub CLI)
+gh pr create --base main --head codex-site-fresh-20250930 --fill
+```
+
+Remplacez la dernière commande par votre méthode de création de PR si vous n'utilisez pas GitHub CLI.

--- a/generated/codex-site-20250930/assets/icons/icon-192.png.placeholder
+++ b/generated/codex-site-20250930/assets/icons/icon-192.png.placeholder
@@ -1,0 +1,1 @@
+remplacer par icon-192.png

--- a/generated/codex-site-20250930/assets/icons/icon.svg
+++ b/generated/codex-site-20250930/assets/icons/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#334155" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="40" fill="url(#grad)" />
+  <path d="M58 96c0-21 17-38 38-38s38 17 38 38-17 38-38 38-38-17-38-38zm38-52c-28.7 0-52 23.3-52 52s23.3 52 52 52 52-23.3 52-52-23.3-52-52-52zm0 32c11 0 20 9 20 20s-9 20-20 20-20-9-20-20 9-20 20-20z" fill="#f8fafc" fill-rule="evenodd" />
+</svg>

--- a/generated/codex-site-20250930/assets/images/hero.jpg.placeholder
+++ b/generated/codex-site-20250930/assets/images/hero.jpg.placeholder
@@ -1,0 +1,1 @@
+remplacer par hero.jpg

--- a/generated/codex-site-20250930/css/styles.css
+++ b/generated/codex-site-20250930/css/styles.css
@@ -1,0 +1,931 @@
+:root {
+    color-scheme: light;
+    --font-sans: "SF Pro Text", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    --font-display: "SF Pro Display", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    --color-background: #f5f7fb;
+    --color-surface: rgba(255, 255, 255, 0.78);
+    --color-surface-solid: #ffffff;
+    --color-border: rgba(27, 43, 99, 0.12);
+    --color-text: #0c1633;
+    --color-muted: #5b6b92;
+    --color-accent: #3b64ff;
+    --color-accent-soft: rgba(59, 100, 255, 0.12);
+    --color-highlight: #9fb6ff;
+    --shadow-soft: 0 18px 44px rgba(15, 33, 66, 0.12);
+    --shadow-sharp: 0 12px 24px rgba(15, 33, 66, 0.18);
+    --radius-large: 32px;
+    --radius-medium: 20px;
+    --radius-small: 12px;
+    --max-width: 1120px;
+    --transition: 220ms ease;
+    --blur: 18px;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    font-size: 100%;
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    background: radial-gradient(circle at 20% 20%, rgba(119, 154, 255, 0.18), transparent 45%),
+        radial-gradient(circle at 80% 0%, rgba(162, 185, 255, 0.12), transparent 40%),
+        linear-gradient(180deg, #f9fbff 0%, #eef3ff 100%);
+    min-height: 100vh;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(82, 118, 255, 0.12), rgba(255, 255, 255, 0));
+    opacity: 0.7;
+    pointer-events: none;
+    z-index: -2;
+}
+
+img,
+svg,
+canvas {
+    max-width: 100%;
+    display: block;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-accent);
+    color: #fff;
+    padding: 0.75rem 1.25rem;
+    border-radius: var(--radius-small);
+    font-weight: 600;
+    transition: top var(--transition);
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    top: 12px;
+}
+
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    backdrop-filter: blur(var(--blur));
+    background: rgba(245, 247, 251, 0.85);
+    border-bottom: 1px solid transparent;
+    transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.header.is-scrolled {
+    background: rgba(239, 244, 255, 0.92);
+    border-color: var(--color-border);
+    box-shadow: 0 10px 30px rgba(19, 36, 78, 0.08);
+}
+
+.header__inner {
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.logo {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    color: var(--color-text);
+}
+
+.nav {
+    position: relative;
+}
+
+.nav__toggle {
+    display: none;
+    background: rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(59, 100, 255, 0.2);
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--color-text);
+    transition: background var(--transition), transform var(--transition);
+}
+
+.nav__toggle:focus-visible,
+.nav__toggle:hover {
+    background: rgba(59, 100, 255, 0.12);
+    transform: translateY(-1px);
+}
+
+.nav__list {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 1rem;
+}
+
+.nav__list a {
+    text-decoration: none;
+    color: var(--color-muted);
+    font-weight: 600;
+    padding: 0.6rem 1rem;
+    border-radius: 999px;
+    transition: color var(--transition), background var(--transition), box-shadow var(--transition);
+}
+
+.nav__list a:focus-visible,
+.nav__list a:hover {
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: inset 0 0 0 1px rgba(59, 100, 255, 0.12);
+}
+
+.hero {
+    position: relative;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    align-items: center;
+    min-height: clamp(520px, 88vh, 760px);
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 4.5rem 1.5rem 4rem;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 2.5rem;
+    z-index: -1;
+    border-radius: var(--radius-large);
+    background: rgba(255, 255, 255, 0.48);
+    filter: blur(0px);
+    box-shadow: 0 24px 68px rgba(15, 33, 66, 0.16);
+    opacity: 0.65;
+}
+
+.hero__content {
+    display: grid;
+    gap: 1.25rem;
+    position: relative;
+    z-index: 2;
+}
+
+.hero__kicker {
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    font-size: 0.85rem;
+}
+
+.hero__title {
+    font-family: var(--font-display);
+    font-size: clamp(2.25rem, 5vw, 3.6rem);
+    margin: 0;
+    line-height: 1.05;
+}
+
+.hero__subtitle {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--color-muted);
+    max-width: 34ch;
+}
+
+.hero__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.hero__visual {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: var(--radius-large);
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(59, 100, 255, 0.75), rgba(168, 187, 255, 0.4));
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    place-items: center;
+}
+
+.hero__visual::before,
+.hero__visual::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(30px);
+    opacity: 0.85;
+}
+
+.hero__visual::before {
+    width: 280px;
+    height: 280px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.95), rgba(59, 100, 255, 0));
+    animation: floatOrb 12s ease-in-out infinite;
+}
+
+.hero__visual::after {
+    width: 420px;
+    height: 420px;
+    background: radial-gradient(circle, rgba(150, 173, 255, 0.5), transparent);
+    animation: floatOrbAlt 16s ease-in-out infinite;
+}
+
+#particle-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    mix-blend-mode: screen;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.8rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--color-accent);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    box-shadow: 0 12px 30px rgba(59, 100, 255, 0.35);
+}
+
+.btn:focus-visible,
+.btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(59, 100, 255, 0.45);
+}
+
+.btn--ghost {
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--color-text);
+    box-shadow: inset 0 0 0 1px rgba(59, 100, 255, 0.25);
+}
+
+.btn--ghost:focus-visible,
+.btn--ghost:hover {
+    background: rgba(255, 255, 255, 0.9);
+}
+
+main {
+    display: grid;
+    gap: 4rem;
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 0 1.5rem 5rem;
+}
+
+.section {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3.5rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.section::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.section:hover::after {
+    opacity: 1;
+}
+
+.section--grid {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.section__header {
+    max-width: 720px;
+}
+
+.section__header h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section__header p {
+    color: var(--color-muted);
+    margin: 1rem 0 0;
+    font-size: 1.05rem;
+}
+
+.topics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+}
+
+.topic-card {
+    display: grid;
+    gap: 0.6rem;
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.25rem 1.4rem;
+    border-radius: var(--radius-medium);
+    text-decoration: none;
+    color: inherit;
+    border: 1px solid transparent;
+    box-shadow: 0 12px 24px rgba(15, 33, 66, 0.08);
+    transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.topic-card:hover,
+.topic-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 36px rgba(15, 33, 66, 0.12);
+    border-color: rgba(59, 100, 255, 0.18);
+    background: rgba(248, 250, 255, 0.95);
+}
+
+.topic-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-family: var(--font-display);
+}
+
+.topic-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery__item {
+    position: relative;
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.65);
+    padding: 1.25rem;
+    display: grid;
+    gap: 0.75rem;
+    box-shadow: 0 14px 36px rgba(19, 36, 78, 0.1);
+}
+
+.gallery__item img {
+    border-radius: var(--radius-small);
+    filter: saturate(1.1);
+    transition: transform 700ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.gallery__item:hover img {
+    transform: scale(1.04);
+}
+
+.gallery__legend {
+    font-size: 0.95rem;
+    color: var(--color-muted);
+}
+
+.scenario {
+    display: grid;
+    gap: 1.25rem;
+    background: rgba(255, 255, 255, 0.86);
+    padding: 2rem;
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.14);
+    box-shadow: 0 16px 40px rgba(15, 33, 66, 0.1);
+}
+
+.scenario__label {
+    font-weight: 600;
+    color: var(--color-muted);
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.scenario__output {
+    display: grid;
+    gap: 0.6rem;
+}
+
+input[type="range"] {
+    width: 100%;
+    accent-color: var(--color-accent);
+}
+
+.badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.badge-list li {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: var(--color-accent-soft);
+    color: var(--color-accent);
+    font-weight: 600;
+}
+
+.footer {
+    padding: 3rem 1.5rem;
+    text-align: center;
+    color: var(--color-muted);
+}
+
+.footer p {
+    margin: 0.4rem 0;
+}
+
+.reveal {
+    opacity: 0;
+    transform: translateY(32px);
+    transition: opacity 600ms ease, transform 600ms ease;
+}
+
+.reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@keyframes floatOrb {
+    0%,
+    100% {
+        transform: translate(0, 0) scale(1);
+    }
+    50% {
+        transform: translate(-12px, 18px) scale(1.08);
+    }
+}
+
+@keyframes floatOrbAlt {
+    0%,
+    100% {
+        transform: translate(0, 0) scale(0.98);
+    }
+    40% {
+        transform: translate(16px, -12px) scale(1.06);
+    }
+}
+
+.page {
+    background: none;
+}
+
+.page__main {
+    display: grid;
+    gap: 3rem;
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 4rem 1.5rem 5rem;
+}
+
+.page__hero {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3.5rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.page__hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.8), rgba(225, 234, 255, 0.1));
+    z-index: -1;
+}
+
+.page__hero-text {
+    display: grid;
+    gap: 1rem;
+}
+
+.page__kicker {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    font-size: 0.85rem;
+}
+
+.page__title {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0;
+}
+
+.page__subtitle {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 1.05rem;
+}
+
+.page__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.page__hero-figure {
+    position: relative;
+    padding: 1rem;
+}
+
+.page__hero-figure::before {
+    content: "";
+    position: absolute;
+    inset: 10%;
+    border-radius: var(--radius-large);
+    background: linear-gradient(135deg, rgba(59, 100, 255, 0.18), rgba(255, 255, 255, 0));
+    filter: blur(0px);
+    z-index: -1;
+}
+
+.page__illustration {
+    width: 100%;
+    border-radius: var(--radius-medium);
+    box-shadow: var(--shadow-sharp);
+    background: #fff;
+}
+
+.page__summary {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-card {
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.75rem;
+    border-radius: var(--radius-medium);
+    box-shadow: 0 16px 36px rgba(15, 33, 66, 0.1);
+    border: 1px solid rgba(59, 100, 255, 0.12);
+    display: grid;
+    gap: 0.6rem;
+}
+
+.summary-card h2,
+.summary-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.summary-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.page__narrative,
+.page__interactive,
+.page__checklist,
+.page__resources {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.page__narrative::after,
+.page__interactive::after,
+.page__checklist::after,
+.page__resources::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.page__narrative:hover::after,
+.page__interactive:hover::after,
+.page__checklist:hover::after,
+.page__resources:hover::after {
+    opacity: 1;
+}
+
+.narrative-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.narrative-block {
+    background: rgba(255, 255, 255, 0.9);
+    padding: 1.5rem;
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.1);
+    box-shadow: 0 14px 30px rgba(19, 36, 78, 0.1);
+    display: grid;
+    gap: 0.75rem;
+    position: relative;
+}
+
+.narrative-block::before {
+    content: "";
+    position: absolute;
+    top: 1.2rem;
+    left: 1.2rem;
+    width: 40px;
+    height: 3px;
+    background: linear-gradient(90deg, var(--color-accent), transparent);
+    border-radius: 999px;
+}
+
+.narrative-block h3 {
+    margin: 0;
+    padding-top: 0.5rem;
+    font-size: 1.2rem;
+    font-family: var(--font-display);
+}
+
+.narrative-block p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.timeline {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: var(--radius-medium);
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(59, 100, 255, 0.12);
+    box-shadow: 0 16px 32px rgba(15, 33, 66, 0.1);
+}
+
+.timeline__display {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.timeline__display h3 {
+    margin: 0;
+}
+
+.timeline__display p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.insight {
+    display: grid;
+    gap: 1rem;
+}
+
+.insight__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.insight__tabs button {
+    border: 1px solid rgba(59, 100, 255, 0.2);
+    border-radius: 999px;
+    padding: 0.6rem 1rem;
+    background: rgba(255, 255, 255, 0.75);
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-muted);
+    transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.insight__tabs button[aria-selected="true"],
+.insight__tabs button:hover,
+.insight__tabs button:focus-visible {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(59, 100, 255, 0.3);
+}
+
+.insight__panel {
+    min-height: 3.5rem;
+    color: var(--color-text);
+    font-size: 1.05rem;
+}
+
+.checklist {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.checklist li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: start;
+    padding: 0.9rem 1.2rem;
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.14);
+    box-shadow: 0 12px 26px rgba(19, 36, 78, 0.08);
+}
+
+.checklist li::before {
+    content: "";
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    margin-top: 0.25rem;
+    background: radial-gradient(circle at 30% 30%, #fff, var(--color-accent));
+    box-shadow: 0 0 0 3px rgba(59, 100, 255, 0.15);
+}
+
+.resource-list {
+    list-style: none;
+    display: grid;
+    gap: 0.8rem;
+    margin: 1.5rem 0 0;
+    padding: 0;
+}
+
+.resource-list a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    color: var(--color-accent);
+    font-weight: 600;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.resource-list a:hover,
+.resource-list a:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(15, 33, 66, 0.15);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(59, 100, 255, 0.12);
+    color: var(--color-accent);
+}
+
+[data-sparkle] {
+    position: relative;
+    overflow: hidden;
+}
+
+[data-sparkle]::after {
+    content: "";
+    position: absolute;
+    inset: -120%;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
+    transform: rotate(12deg);
+    animation: shimmer 8s linear infinite;
+    pointer-events: none;
+    opacity: 0.35;
+}
+
+@keyframes shimmer {
+    0% {
+        transform: translateX(-60%) rotate(12deg);
+    }
+    100% {
+        transform: translateX(60%) rotate(12deg);
+    }
+}
+
+.procedural-art {
+    aspect-ratio: 16 / 10;
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+    background: linear-gradient(140deg, rgba(59, 100, 255, 0.2), rgba(199, 210, 255, 0.4));
+    box-shadow: var(--shadow-soft);
+}
+
+.procedural-art img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+@media (max-width: 960px) {
+    .hero {
+        grid-template-columns: 1fr;
+        padding: 4rem 1.25rem;
+    }
+
+    .hero::after {
+        inset: 1.5rem;
+    }
+
+    .hero__visual {
+        order: -1;
+        aspect-ratio: 3 / 2;
+    }
+
+    .nav__toggle {
+        display: inline-flex;
+    }
+
+    .nav__list {
+        position: absolute;
+        right: 0;
+        top: calc(100% + 0.75rem);
+        background: rgba(255, 255, 255, 0.95);
+        border-radius: var(--radius-medium);
+        box-shadow: var(--shadow-sharp);
+        padding: 1rem;
+        flex-direction: column;
+        align-items: flex-start;
+        min-width: 220px;
+        transform-origin: top right;
+        transform: scale(0.9);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity var(--transition), transform var(--transition), visibility var(--transition);
+    }
+
+    .nav__list.is-open {
+        transform: scale(1);
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+@media (max-width: 720px) {
+    main {
+        padding: 0 1.25rem 4rem;
+        gap: 3rem;
+    }
+
+    .section {
+        padding: 2rem;
+    }
+
+    .page__main {
+        padding: 3.5rem 1.25rem 4rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 1ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .reveal {
+        opacity: 1 !important;
+        transform: none !important;
+    }
+}

--- a/generated/codex-site-20250930/index.html
+++ b/generated/codex-site-20250930/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Plateforme hors ligne élégante dédiée à la sécurité des IA : 25 domaines, méthodologies et outils pour anticiper les risques.">
+    <meta name="offline-ready" content="true">
+    <title>SafeIntelligence – Sécurité des IA</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" type="image/svg+xml" href="assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <link rel="stylesheet" href="css/styles.css">
+    <script defer src="js/page-data.js"></script>
+    <script defer src="js/app.js"></script>
+    <script defer src="js/sw-register.js"></script>
+</head>
+<body>
+    <a class="skip-link" href="#main">Passer au contenu</a>
+    <header class="header" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="pages/alignment.html">Alignement</a></li>
+                    <li><a href="pages/interpretability.html">Interprétabilité</a></li>
+                    <li><a href="pages/governance.html">Gouvernance</a></li>
+                    <li><a href="pages/red-teaming.html">Red Teaming</a></li>
+                    <li><a href="pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="hero" id="hero">
+        <canvas id="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero__content">
+            <p class="hero__kicker">Sécurité des intelligences artificielles</p>
+            <h1 class="hero__title">L'expérience hors ligne qui élève la résilience de vos IA.</h1>
+            <p class="hero__subtitle">Découvrez un parcours complet, élégant et opérationnel pour couvrir l'alignement, l'interprétabilité, la gouvernance et l'ensemble des disciplines critiques de la sécurité des IA.</p>
+            <div class="hero__cta">
+                <a class="btn" href="#sections">Explorer les domaines</a>
+                <button class="btn btn--ghost" data-scroll-target="#scenario">Composer une stratégie</button>
+            </div>
+            <ul class="badge-list" aria-label="Bénéfices clés">
+                <li>25 domaines d'expertise</li>
+                <li>Animations immersives</li>
+                <li>PWA 100% hors ligne</li>
+            </ul>
+        </div>
+        <div class="hero__visual" aria-hidden="true">
+            <div class="hero__visual-glow"></div>
+        </div>
+    </section>
+
+    <main id="main">
+        <section class="section section--grid reveal" id="sections" aria-labelledby="overview-title">
+            <div class="section__header">
+                <h2 id="overview-title">Un atlas raffiné des risques IA</h2>
+                <p>Nos 25 pages thématiques livrent une vision opérationnelle : cadrage stratégique, gouvernance, architecture, supervision et réponse aux incidents. Chaque sujet bénéficie d'illustrations génératives, de plans d'action et d'interactions guidées.</p>
+            </div>
+            <div class="topics-grid" role="list">
+                <a class="topic-card" role="listitem" href="pages/alignment.html">
+                    <h3>Alignement</h3>
+                    <p>Orchestrez des objectifs sûrs et contrôlables.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/interpretability.html">
+                    <h3>Interprétabilité</h3>
+                    <p>Exposez les décisions pour renforcer la confiance.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/scheming.html">
+                    <h3>Comportements stratégiques</h3>
+                    <p>Détectez les détours opportunistes et les dérives.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/robustness.html">
+                    <h3>Robustesse</h3>
+                    <p>Résistez aux perturbations et scénarios extrêmes.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/dataset-security.html">
+                    <h3>Sécurité des données</h3>
+                    <p>Préservez l'intégrité de vos jeux d'entraînement.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/oversight.html">
+                    <h3>Supervision humaine</h3>
+                    <p>Choregraphiez les boucles de validation critiques.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/governance.html">
+                    <h3>Gouvernance</h3>
+                    <p>Clarifiez rôles, contrôles et reporting.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/threat-modeling.html">
+                    <h3>Modélisation des menaces</h3>
+                    <p>Priorisez les efforts à forte valeur défensive.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/auditing.html">
+                    <h3>Audit des systèmes</h3>
+                    <p>Industrialisez la vérification des pipelines.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/transparency.html">
+                    <h3>Transparence</h3>
+                    <p>Partager sans trahir vos secrets industriels.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/monitoring.html">
+                    <h3>Surveillance continue</h3>
+                    <p>Captez les signaux faibles en temps réel.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/incident-response.html">
+                    <h3>Réponse aux incidents</h3>
+                    <p>Réagissez vite avec un plan orchestré.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/adversarial-learning.html">
+                    <h3>Apprentissage adversarial</h3>
+                    <p>Éprouvez vos modèles par le feu contrôlé.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/differential-privacy.html">
+                    <h3>Confidentialité différentielle</h3>
+                    <p>Formalisez la protection de chaque donnée.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/secure-architecture.html">
+                    <h3>Architecture sécurisée</h3>
+                    <p>Installez des garde-fous à chaque étage.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/human-in-the-loop.html">
+                    <h3>Humain dans la boucle</h3>
+                    <p>Composez des symbioses homme-machine efficaces.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/policy.html">
+                    <h3>Politiques internes</h3>
+                    <p>Diffusez une culture de sécurité unifiée.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/evaluation.html">
+                    <h3>Évaluations de sécurité</h3>
+                    <p>Mesurez la maturité et les progrès obtenus.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/red-teaming.html">
+                    <h3>Red Teaming IA</h3>
+                    <p>Dévoilez les failles avant l'adversaire.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/ethics.html">
+                    <h3>Éthique & sécurité</h3>
+                    <p>Alliez ambitions responsables et rigueur.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/supply-chain.html">
+                    <h3>Chaîne d'approvisionnement</h3>
+                    <p>Verrouillez dépendances, packages et APIs.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/hardware-security.html">
+                    <h3>Sécurité matérielle</h3>
+                    <p>Gardez le contrôle sur les accélérateurs IA.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/fail-safes.html">
+                    <h3>Mécanismes de repli</h3>
+                    <p>Préparez des arrêts gracieux et contrôlés.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/regulation.html">
+                    <h3>Régulation</h3>
+                    <p>Devancez les cadres internationaux.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/contact.html">
+                    <h3>Contact</h3>
+                    <p>Construisons votre programme sur mesure.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="section reveal" aria-labelledby="craft-title" data-sparkle>
+            <div class="section__header">
+                <h2 id="craft-title">Des parcours chorégraphiés pour chaque enjeu</h2>
+                <p>Animations discrètes, contrastes maîtrisés et contenus interactifs guident vos équipes à travers les décisions clés : cadrage, prévention, détection et réponse. L'expérience s'adapte à toutes les tailles d'écran sans dépendance à un réseau.</p>
+            </div>
+            <div class="gallery" aria-label="Illustrations génératives">
+                <figure class="gallery__item procedural-art">
+                    <img data-art="alignment" alt="Illustration générée sur l'alignement des IA">
+                    <figcaption class="gallery__legend">Alignement : des gradients doux symbolisent la convergence contrôlée des objectifs.</figcaption>
+                </figure>
+                <figure class="gallery__item procedural-art">
+                    <img data-art="robustness" alt="Illustration générée sur la robustesse des modèles">
+                    <figcaption class="gallery__legend">Robustesse : superposition de halos pour visualiser la résilience multicouche.</figcaption>
+                </figure>
+                <figure class="gallery__item procedural-art">
+                    <img data-art="governance" alt="Illustration générée sur la gouvernance IA">
+                    <figcaption class="gallery__legend">Gouvernance : architecture claire et hiérarchisée, inspirée des organigrammes premium.</figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <section class="section reveal" id="scenario" aria-labelledby="scenario-title">
+            <div class="section__header">
+                <h2 id="scenario-title">Projetez votre feuille de route</h2>
+                <p>Utilisez le curseur pour découvrir les actions prioritaires à chaque étape de votre programme de sécurité IA. Les scénarios sont inspirés des pratiques que nous détaillons dans chacune des pages thématiques.</p>
+            </div>
+            <div class="scenario" data-scenario>
+                <div class="scenario__label">
+                    <span>Phase du programme</span>
+                    <span data-scenario-label>Exploration</span>
+                </div>
+                <input type="range" min="0" max="3" value="0" data-scenario-range aria-label="Sélectionnez la phase de votre programme">
+                <div class="scenario__output" aria-live="polite">
+                    <h3 data-scenario-title>Cartographier les risques</h3>
+                    <p data-scenario-text>Définissez les objectifs critiques, cadrez les cas d'usage et cartographiez les scénarios adverses pour éclairer vos priorités.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section reveal" aria-labelledby="insight-title">
+            <div class="section__header">
+                <h2 id="insight-title">Signaux à suivre dans vos évaluations</h2>
+                <p>Les équipes peuvent activer ces déclencheurs d'analyse pour identifier rapidement un besoin d'audit ou de remédiation. Sélectionnez un signal pour découvrir nos recommandations.</p>
+            </div>
+            <div class="insight" data-insights-home>
+                <div class="insight__tabs" role="tablist" aria-label="Signaux de sécurité">
+                    <button type="button" role="tab" aria-selected="true" data-home-insight="alignement">Alignement</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="interpretabilite">Interprétabilité</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="robustesse">Robustesse</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="gouvernance">Gouvernance</button>
+                </div>
+                <div class="insight__panel" data-home-insight-panel aria-live="polite">
+                    Un modèle modifie ses réponses selon le type d'utilisateur ? Mesurez l'alignement comportemental à l'aide de jeux de tests scénarisés et enclenchez des revues humaines.
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence – Programme de résilience IA hors ligne.</p>
+        <p>Service worker cache-first, manifest PWA et animations 100% locales.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/js/app.js
+++ b/generated/codex-site-20250930/js/app.js
@@ -1,0 +1,427 @@
+(() => {
+    const content = window.safeContent || {};
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const toggle = document.querySelector('.nav__toggle');
+    const list = document.querySelector('.nav__list');
+    if (toggle && list) {
+        toggle.addEventListener('click', () => {
+            const isOpen = list.classList.toggle('is-open');
+            toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+
+        list.addEventListener('click', (event) => {
+            if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+                list.classList.remove('is-open');
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-scroll-target]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const selector = button.getAttribute('data-scroll-target');
+            if (!selector) return;
+            const target = document.querySelector(selector);
+            if (target) {
+                target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+            }
+        });
+    });
+
+    const header = document.querySelector('.header');
+    if (header) {
+        const updateHeader = () => {
+            if (window.scrollY > 24) {
+                header.classList.add('is-scrolled');
+            } else {
+                header.classList.remove('is-scrolled');
+            }
+        };
+        window.addEventListener('scroll', updateHeader, { passive: true });
+        updateHeader();
+    }
+
+    const revealElements = document.querySelectorAll('.reveal');
+    if (revealElements.length) {
+        const onIntersect = (entries, observer) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        };
+        if (!prefersReducedMotion && 'IntersectionObserver' in window) {
+            const observer = new IntersectionObserver(onIntersect, {
+                rootMargin: '0px 0px -10%',
+                threshold: 0.15,
+            });
+            revealElements.forEach((el) => observer.observe(el));
+        } else {
+            revealElements.forEach((el) => el.classList.add('is-visible'));
+        }
+    }
+
+    const canvas = document.getElementById('particle-canvas');
+    if (canvas && canvas instanceof HTMLCanvasElement && !prefersReducedMotion) {
+        const context = canvas.getContext('2d');
+        if (context) {
+            const particles = [];
+            const particleCount = 90;
+            const color = 'rgba(74, 111, 255, 0.55)';
+
+            const resize = () => {
+                canvas.width = canvas.clientWidth;
+                canvas.height = canvas.clientHeight;
+            };
+            resize();
+            window.addEventListener('resize', resize);
+
+            for (let i = 0; i < particleCount; i += 1) {
+                particles.push({
+                    x: Math.random() * canvas.width,
+                    y: Math.random() * canvas.height,
+                    radius: Math.random() * 2 + 0.6,
+                    velocityX: (Math.random() - 0.5) * 0.45,
+                    velocityY: (Math.random() - 0.5) * 0.45,
+                });
+            }
+
+            const draw = () => {
+                context.clearRect(0, 0, canvas.width, canvas.height);
+                particles.forEach((particle) => {
+                    context.beginPath();
+                    context.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+                    context.fillStyle = color;
+                    context.fill();
+                });
+            };
+
+            const update = () => {
+                particles.forEach((particle) => {
+                    particle.x += particle.velocityX;
+                    particle.y += particle.velocityY;
+
+                    if (particle.x < 0 || particle.x > canvas.width) {
+                        particle.velocityX *= -1;
+                    }
+                    if (particle.y < 0 || particle.y > canvas.height) {
+                        particle.velocityY *= -1;
+                    }
+                });
+            };
+
+            const connect = () => {
+                for (let i = 0; i < particles.length; i += 1) {
+                    for (let j = i + 1; j < particles.length; j += 1) {
+                        const dx = particles[i].x - particles[j].x;
+                        const dy = particles[i].y - particles[j].y;
+                        const distance = Math.sqrt(dx * dx + dy * dy);
+                        if (distance < 150) {
+                            context.strokeStyle = `rgba(74, 111, 255, ${0.4 - distance / 360})`;
+                            context.lineWidth = 0.6;
+                            context.beginPath();
+                            context.moveTo(particles[i].x, particles[i].y);
+                            context.lineTo(particles[j].x, particles[j].y);
+                            context.stroke();
+                        }
+                    }
+                }
+            };
+
+            let animationId;
+            const animate = () => {
+                update();
+                draw();
+                connect();
+                animationId = window.requestAnimationFrame(animate);
+            };
+            animate();
+
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) {
+                    window.cancelAnimationFrame(animationId);
+                } else {
+                    animationId = window.requestAnimationFrame(animate);
+                }
+            });
+        }
+    }
+
+    const scenarioData = [
+        {
+            label: 'Exploration',
+            title: 'Cartographier les risques',
+            text: "Identifiez les cas d'usage sensibles, recensez les données critiques et clarifiez les attentes métiers pour donner un cadre au programme de sécurité IA.",
+        },
+        {
+            label: 'Cadre',
+            title: 'Structurer la gouvernance',
+            text: "Mettre en place les comités, politiques et chartes qui encadrent l'usage des modèles et assignent les rôles de supervision.",
+        },
+        {
+            label: 'Déploiement',
+            title: 'Industrialiser les contrôles',
+            text: "Automatisez tests, évaluations et surveillance continue pour réduire les temps de réaction face aux signaux faibles.",
+        },
+        {
+            label: 'Optimisation',
+            title: 'Mesurer et améliorer',
+            text: "Consolidez vos indicateurs, partagez les leçons apprises et ajustez la feuille de route selon les incidents et retours terrain.",
+        },
+    ];
+
+    const scenarioRange = document.querySelector('[data-scenario-range]');
+    if (scenarioRange) {
+        const labelEl = document.querySelector('[data-scenario-label]');
+        const titleEl = document.querySelector('[data-scenario-title]');
+        const textEl = document.querySelector('[data-scenario-text]');
+        const updateScenario = (index) => {
+            const step = scenarioData[index] || scenarioData[0];
+            if (labelEl) labelEl.textContent = step.label;
+            if (titleEl) titleEl.textContent = step.title;
+            if (textEl) textEl.textContent = step.text;
+        };
+        scenarioRange.setAttribute('max', String(scenarioData.length - 1));
+        scenarioRange.addEventListener('input', (event) => {
+            const value = Number(event.target.value || 0);
+            updateScenario(value);
+        });
+        updateScenario(Number(scenarioRange.value || 0));
+    }
+
+    const homeInsights = {
+        alignement: "Un modèle modifie ses réponses selon le type d'utilisateur ? Mesurez l'alignement comportemental à l'aide de jeux de tests scénarisés et enclenchez des revues humaines.",
+        interpretabilite: "Les équipes peinent à expliquer une décision critique ? Réunissez data scientists et métier pour produire une narration accessible et archiver l'analyse.",
+        robustesse: "Vos stress tests révèlent des écarts extrêmes ? Priorisez les cas d'usage vitaux, ajoutez des protections en amont et surveillez la dérive.",
+        gouvernance: "Plusieurs équipes déploient des modèles sans validation ? Activez votre comité IA et imposez un pipeline approuvé avant mise en production.",
+    };
+    const homePanel = document.querySelector('[data-home-insight-panel]');
+    const homeButtons = document.querySelectorAll('[data-home-insight]');
+    if (homePanel && homeButtons.length) {
+        homeButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                homeButtons.forEach((other) => other.setAttribute('aria-selected', 'false'));
+                button.setAttribute('aria-selected', 'true');
+                const key = button.getAttribute('data-home-insight');
+                homePanel.textContent = homeInsights[key] || '';
+            });
+        });
+    }
+
+    const seedRandom = (seed) => {
+        let h = 0;
+        for (let i = 0; i < seed.length; i += 1) {
+            h = Math.imul(31, h) + seed.charCodeAt(i) | 0;
+        }
+        return () => {
+            h = Math.imul(h ^ h >>> 15, 1 | h);
+            h = h + Math.imul(h ^ h >>> 7, 61 | h) ^ h;
+            return ((h ^ h >>> 14) >>> 0) / 4294967296;
+        };
+    };
+
+    const drawRoundedRect = (ctx, x, y, width, height, radius) => {
+        const r = Math.min(radius, width / 2, height / 2);
+        ctx.beginPath();
+        ctx.moveTo(x + r, y);
+        ctx.lineTo(x + width - r, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+        ctx.lineTo(x + width, y + height - r);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+        ctx.lineTo(x + r, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+        ctx.lineTo(x, y + r);
+        ctx.quadraticCurveTo(x, y, x + r, y);
+        ctx.closePath();
+    };
+
+    const createProceduralArt = (slug, palette, accent) => {
+        const canvasEl = document.createElement('canvas');
+        canvasEl.width = 960;
+        canvasEl.height = 600;
+        const ctx = canvasEl.getContext('2d');
+        if (!ctx) return '';
+
+        const random = seedRandom(slug);
+        const gradient = ctx.createLinearGradient(0, 0, canvasEl.width, canvasEl.height);
+        gradient.addColorStop(0, palette[0] || '#e8edff');
+        gradient.addColorStop(1, palette[1] || '#f6f8ff');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
+
+        for (let i = 0; i < 8; i += 1) {
+            const cx = canvasEl.width * random();
+            const cy = canvasEl.height * random();
+            const radius = 180 + random() * 220;
+            const gradientCircle = ctx.createRadialGradient(cx, cy, radius * 0.1, cx, cy, radius);
+            gradientCircle.addColorStop(0, `${accent}33`);
+            gradientCircle.addColorStop(1, '#ffffff00');
+            ctx.fillStyle = gradientCircle;
+            ctx.beginPath();
+            ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.globalCompositeOperation = 'lighter';
+        for (let i = 0; i < 60; i += 1) {
+            const x1 = canvasEl.width * random();
+            const y1 = canvasEl.height * random();
+            const x2 = x1 + (random() - 0.5) * 220;
+            const y2 = y1 + (random() - 0.5) * 220;
+            ctx.strokeStyle = `${accent}${Math.floor(120 + random() * 80).toString(16)}`.slice(0, 7);
+            ctx.lineWidth = 1 + random() * 2;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.quadraticCurveTo((x1 + x2) / 2 + random() * 120, (y1 + y2) / 2 + random() * 120, x2, y2);
+            ctx.stroke();
+        }
+        ctx.globalCompositeOperation = 'source-over';
+
+        ctx.lineWidth = 4;
+        ctx.strokeStyle = `${accent}80`;
+        for (let i = 0; i < 4; i += 1) {
+            const startX = canvasEl.width * random();
+            const startY = canvasEl.height * random();
+            const width = 180 + random() * 200;
+            const height = 90 + random() * 140;
+            drawRoundedRect(ctx, startX, startY, width, height, 42);
+            ctx.stroke();
+        }
+
+        return canvasEl.toDataURL('image/png');
+    };
+
+    const updateArtworks = () => {
+        document.querySelectorAll('img[data-art]').forEach((image) => {
+            const slug = image.getAttribute('data-art') || 'default';
+            const palette = content[slug]?.art?.palette || ['#e9eeff', '#f6f8ff'];
+            const accent = content[slug]?.art?.accent || '#3b64ff';
+            const dataUrl = createProceduralArt(slug, palette, accent);
+            if (dataUrl) {
+                image.src = dataUrl;
+            }
+        });
+    };
+    updateArtworks();
+
+    const topic = document.body?.dataset?.topic;
+    if (topic && content[topic]) {
+        const topicData = content[topic];
+        const metaDescription = document.querySelector('meta[name="description"]');
+        if (metaDescription) {
+            metaDescription.setAttribute('content', topicData.description);
+        }
+        if (document.title && !document.title.includes(topicData.title)) {
+            document.title = `${topicData.title} – Sécurité des IA`;
+        }
+
+        document.querySelectorAll('[data-field]').forEach((element) => {
+            const key = element.getAttribute('data-field');
+            if (key && typeof topicData[key] === 'string') {
+                element.textContent = topicData[key];
+            }
+        });
+
+        const narrativeGrid = document.querySelector('[data-narrative-grid]');
+        if (narrativeGrid) {
+            narrativeGrid.innerHTML = '';
+            topicData.narratives.forEach((item) => {
+                const block = document.createElement('article');
+                block.className = 'narrative-block';
+                const heading = document.createElement('h3');
+                heading.textContent = item.title;
+                block.appendChild(heading);
+                item.paragraphs.forEach((paragraph) => {
+                    const p = document.createElement('p');
+                    p.textContent = paragraph;
+                    block.appendChild(p);
+                });
+                narrativeGrid.appendChild(block);
+            });
+        }
+
+        const checklist = document.querySelector('[data-checklist]');
+        if (checklist) {
+            checklist.innerHTML = '';
+            topicData.checklist.forEach((item) => {
+                const li = document.createElement('li');
+                const text = document.createElement('p');
+                text.textContent = item;
+                li.appendChild(text);
+                checklist.appendChild(li);
+            });
+        }
+
+        const resources = document.querySelector('[data-resources]');
+        if (resources) {
+            resources.innerHTML = '';
+            topicData.resources.forEach((resource) => {
+                const li = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = resource.href;
+                link.textContent = resource.label;
+                li.appendChild(link);
+                resources.appendChild(li);
+            });
+        }
+
+        const timelineRange = document.querySelector('[data-timeline-range]');
+        const timelineTitle = document.querySelector('[data-timeline-title]');
+        const timelineText = document.querySelector('[data-timeline-text]');
+        const updateTimeline = (index) => {
+            const item = topicData.timeline[index] || topicData.timeline[0];
+            if (timelineTitle) timelineTitle.textContent = item.label;
+            if (timelineText) timelineText.textContent = item.description;
+        };
+        if (timelineRange) {
+            timelineRange.setAttribute('max', String(topicData.timeline.length - 1));
+            timelineRange.addEventListener('input', (event) => {
+                const value = Number(event.target.value || 0);
+                updateTimeline(value);
+            });
+            updateTimeline(Number(timelineRange.value || 0));
+        }
+
+        const insightTabs = document.querySelector('[data-insight-tabs]');
+        const insightDisplay = document.querySelector('[data-insight-display]');
+        const applyInsight = (index) => {
+            const insight = topicData.insights[index] || topicData.insights[0];
+            if (insightDisplay) {
+                insightDisplay.textContent = insight.detail;
+            }
+        };
+        if (insightTabs && insightDisplay) {
+            insightTabs.innerHTML = '';
+            topicData.insights.forEach((insight, index) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.textContent = insight.label;
+                button.setAttribute('role', 'tab');
+                button.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+                button.addEventListener('click', () => {
+                    insightTabs.querySelectorAll('button').forEach((other) => other.setAttribute('aria-selected', 'false'));
+                    button.setAttribute('aria-selected', 'true');
+                    applyInsight(index);
+                });
+                insightTabs.appendChild(button);
+            });
+            applyInsight(0);
+        }
+
+        const randomButtons = document.querySelectorAll('[data-random-insight]');
+        if (randomButtons.length && topicData.insights.length) {
+            randomButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    const index = Math.floor(Math.random() * topicData.insights.length);
+                    if (insightTabs) {
+                        const buttons = insightTabs.querySelectorAll('button');
+                        buttons.forEach((btn, btnIndex) => btn.setAttribute('aria-selected', btnIndex === index ? 'true' : 'false'));
+                    }
+                    applyInsight(index);
+                });
+            });
+        }
+    }
+})();

--- a/generated/codex-site-20250930/js/page-data.js
+++ b/generated/codex-site-20250930/js/page-data.js
@@ -1,0 +1,1356 @@
+window.safeContent = {
+    "alignment": {
+        "title": "Alignement des IA",
+        "kicker": "Alignement stratégique",
+        "subtitle": "Coordonnez les intentions des modèles avec les valeurs de l'entreprise et la réglementation.",
+        "description": "Approches, signaux et garde-fous pour aligner les intelligences artificielles sur vos objectifs.",
+        "challenge": "Les objectifs implicites des modèles peuvent diverger des attentes humaines et créer des dommages collatéraux.",
+        "approach": "Formalisez des chartes d'entraînement, des tests d'alignement comportemental et des revues interfonctionnelles.",
+        "indicator": "Taux de non-conformité comportementale détecté par vos batteries de scénarios de tests contextualisés.",
+        "interactiveIntro": "Chaque étape d'un programme d'alignement renforce la granularité des garde-fous et la responsabilité partagée.",
+        "narratives": [
+            {
+                "title": "Tracer des frontières comportementales",
+                "paragraphs": [
+                    "L'alignement commence par la traduction des principes métiers et des exigences réglementaires en comportements mesurables. Cela implique de documenter les scénarios acceptables, les zones grises et les situations à bannir, puis de relier ces éléments aux jeux d'entraînement et aux données de renforcement.",
+                    "Les ateliers d'alignement gagnent en efficacité lorsqu'ils rassemblent métier, juridique, sécurité et utilisateurs finaux. Ensemble, ils établissent un lexique partagé pour qualifier la conformité des réponses générées et éviter les malentendus entre équipes."
+                ]
+            },
+            {
+                "title": "Institutionnaliser les revues humaines",
+                "paragraphs": [
+                    "Un programme mature prévoit des comités de décision qui évaluent régulièrement les compromis de performance versus alignement. Ils examinent les résultats de tests adversariaux, les journaux d'incidents et les feedbacks utilisateurs pour arbitrer les évolutions de modèles."
+                ]
+            },
+            {
+                "title": "Mesurer et corriger en continu",
+                "paragraphs": [
+                    "Les métriques d'alignement sont dynamiques : vous avez besoin de tableaux de bord qui associent scores comportementaux, couverture de tests et saturation des processus de validation humaine. Les seuils d'alerte doivent déclencher des boucles d'amélioration rapides."
+                ]
+            }
+        ],
+        "checklist": [
+            "Cartographier les principes éthiques et réglementaires applicables à chaque cas d'usage.",
+            "Développer des jeux de tests comportementaux contextualisés par segment utilisateur.",
+            "Mettre en place un comité d'arbitrage alignement/performance avec pouvoir décisionnel.",
+            "Documenter les incidents et dérives pour enrichir les règles d'entraînement et de déploiement."
+        ],
+        "timeline": [
+            {"label": "Exploration", "description": "Identifier les écarts potentiels entre objectifs métiers et apprentissage spontané du modèle."},
+            {"label": "Structuration", "description": "Créer des chartes d'alignement, formaliser les critères d'acceptation et les seuils d'alerte."},
+            {"label": "Opérationnalisation", "description": "Industrialiser les tests de régression, les revues humaines et les validations multi-équipes."},
+            {"label": "Maîtrise", "description": "Automatiser la détection des dérives et activer des plans de correction orchestrés en continu."}
+        ],
+        "insights": [
+            {"label": "Signal métier", "detail": "Des agents prennent des initiatives hors périmètre ? Revoyez les prompts systèmes et imposez des garde-fous d'autorisation."},
+            {"label": "Signal juridique", "detail": "Une recommandation enfreint un cadre réglementaire ? Programmez une suspension automatique du modèle concerné."},
+            {"label": "Signal utilisateur", "detail": "Les retours clients indiquent un ton inadapté ? Ajustez les données d'exemples et la pondération des objectifs."}
+        ],
+        "resources": [
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"}
+        ],
+        "art": {"palette": ["#dbe4ff", "#edf0ff", "#fafcff"], "accent": "#3b64ff"},
+        "artDescription": "Illustration générative évoquant la convergence de flux alignés."
+    },
+    "interpretability": {
+        "title": "Interprétabilité",
+        "kicker": "Transparence cognitive",
+        "subtitle": "Exposez les décisions algorithmiques pour faciliter l'audit et la confiance des parties prenantes.",
+        "description": "Techniques d'explicabilité, cartographies de features et protocoles de restitution pour vos IA.",
+        "challenge": "Sans transparence, impossible de comprendre ou de contester un résultat critique produit par le modèle.",
+        "approach": "Combinez interprétabilité intrinsèque, outils post-hoc et documentations de données pour couvrir tous les angles.",
+        "indicator": "Temps moyen nécessaire pour expliquer une décision critique à un auditeur externe.",
+        "interactiveIntro": "Chaque phase améliore la granularité des explications et la fluidité de vos restitutions.",
+        "narratives": [
+            {
+                "title": "Composer une carte de lecture",
+                "paragraphs": [
+                    "L'interprétabilité efficace repose sur une bibliothèque d'explications prêtes à être utilisées par différents publics. Elle inclut la traçabilité des données sources, l'importance des features et des exemples contrastifs pour illustrer les limites du modèle.",
+                    "Les ateliers de restitution doivent intégrer designers, data scientists et métiers afin de produire des narrations accessibles. L'objectif : livrer des explications courtes, visuelles et actionnables, compatibles avec la pression temporelle des incidents."
+                ]
+            },
+            {
+                "title": "Outiller les analystes",
+                "paragraphs": [
+                    "Les équipes d'investigation ont besoin de tableaux de bord interactifs permettant de rejouer des décisions, comparer des sorties alternatives et détecter des dépendances inattendues."
+                ]
+            },
+            {
+                "title": "Capitaliser sur les retours",
+                "paragraphs": [
+                    "Chaque demande d'explication doit enrichir la base documentaire. Les questions récurrentes révèlent des zones d'ombre que l'on peut éclairer avec de nouveaux scénarios de test et des fiches explicatives orientées métier."
+                ]
+            }
+        ],
+        "checklist": [
+            "Établir des personas d'audience pour calibrer les niveaux de détail attendus.",
+            "Associer à chaque modèle une fiche signalétique décrivant données, limites et responsables.",
+            "Mettre à disposition des notebooks reproductibles pour rejouer une décision sensible.",
+            "Garantir que les explications sont accessibles sur mobile et via des canaux hors ligne."
+        ],
+        "timeline": [
+            {"label": "Diagnostic", "description": "Inventorier les modèles critiques et leurs zones d'opacité."},
+            {"label": "Design", "description": "Concevoir les formats d'explications adaptés à chaque public."},
+            {"label": "Déploiement", "description": "Intégrer les outils d'explicabilité dans les workflows métiers."},
+            {"label": "Amélioration", "description": "Collecter les feedbacks et enrichir la bibliothèque d'exemples."}
+        ],
+        "insights": [
+            {"label": "Signal audit", "detail": "Une décision impactante est restée inexpliquée 48 h ? Escaladez automatiquement au comité d'éthique."},
+            {"label": "Signal produit", "detail": "Des variations de sortie inexpliquées augmentent ? Vérifiez la dérive des features et mettez à jour les dashboards."},
+            {"label": "Signal support", "detail": "Les équipes terrain réclament des supports papier ? Fournissez des fiches synthétiques hors ligne."}
+        ],
+        "resources": [
+            {"label": "Transparence", "href": "../pages/transparency.html"},
+            {"label": "Audit des systèmes", "href": "../pages/auditing.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#e0e9ff", "#cddcff"], "accent": "#566bff"},
+        "artDescription": "Illustration générative suggérant la décomposition d'une décision IA."
+    },
+    "governance": {
+        "title": "Gouvernance IA",
+        "kicker": "Capitainerie des risques",
+        "subtitle": "Établissez un pilotage clair, des rôles définis et des circuits de décision responsables.",
+        "description": "Modèles de gouvernance, comités, politiques et tableaux de bord pour sécuriser vos IA.",
+        "challenge": "Sans chaîne de responsabilité, la sécurité IA reste fragmentée et les incidents se multiplient.",
+        "approach": "Définissez des mandats précis, des politiques approuvées par la direction et des indicateurs de conformité.",
+        "indicator": "Pourcentage de décisions critiques disposant d'un propriétaire clairement identifié.",
+        "interactiveIntro": "La gouvernance s'étoffe d'abord par la définition des rôles, puis par des rituels et enfin par l'automatisation des contrôles.",
+        "narratives": [
+            {
+                "title": "Cartographier la chaîne décisionnelle",
+                "paragraphs": [
+                    "Une gouvernance solide débute par un organigramme de la responsabilité IA, couvrant sponsors, responsables produit, sécurité et juridique. Chaque acteur connaît ses droits, ses devoirs et la manière d'escalader un incident.",
+                    "Les chartes de gouvernance précisent également les niveaux d'approbation requis pour chaque changement de modèle. Elles s'accompagnent de matrices RACI et d'un calendrier de revues."
+                ]
+            },
+            {
+                "title": "Animer les comités",
+                "paragraphs": [
+                    "Les comités de pilotage examinent indicateurs de risque, incidents, dettes techniques et planifient les priorités. Ils arbitrent également les investissements nécessaires pour maintenir la conformité."
+                ]
+            },
+            {
+                "title": "Automatiser les contrôles",
+                "paragraphs": [
+                    "À maturité, la gouvernance intègre des workflows automatisés : demandes de changement, approbations électroniques, notifications en cas de dérive. Cela garantit une réaction rapide tout en conservant la traçabilité."
+                ]
+            }
+        ],
+        "checklist": [
+            "Identifier un sponsor exécutif responsable du programme IA.",
+            "Définir des rôles et responsabilités documentés pour chaque équipe.",
+            "Mettre en place un calendrier de comités avec ordres du jour standardisés.",
+            "Publier des indicateurs de conformité et des plans de remédiation suivis."
+        ],
+        "timeline": [
+            {"label": "Initialisation", "description": "Nommer les sponsors et recenser les modèles critiques."},
+            {"label": "Structuration", "description": "Formaliser les politiques, chartes et circuits d'approbation."},
+            {"label": "Animation", "description": "Faire vivre les comités et publier des rapports réguliers."},
+            {"label": "Optimisation", "description": "Automatiser les contrôles et intégrer la gouvernance dans les outils."}
+        ],
+        "insights": [
+            {"label": "Signal comité", "detail": "Des décisions sensibles sont prises hors comité ? Ajustez le processus d'approbation."},
+            {"label": "Signal indicateur", "detail": "Les KPI de conformité ne sont plus mis à jour ? Identifiez les dépendances bloquantes."},
+            {"label": "Signal équipe", "detail": "Les équipes ignorent qui alerter ? Diffusez des fiches réflexes et un annuaire responsives."}
+        ],
+        "resources": [
+            {"label": "Régulation", "href": "../pages/regulation.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#eaf0ff", "#f5f7ff", "#c8d7ff"], "accent": "#354cff"},
+        "artDescription": "Illustration générative structurée rappelant un organigramme épuré."
+    },
+    "red-teaming": {
+        "title": "Red Teaming IA",
+        "kicker": "Offensive contrôlée",
+        "subtitle": "Testez vos systèmes avec des attaques orchestrées pour découvrir les failles avant les adversaires.",
+        "description": "Méthodologies de red teaming, scripts adversariaux et reporting pour IA génératives et prédictives.",
+        "challenge": "Sans simulations réalistes, les vulnérabilités restent invisibles jusqu'à l'exploitation réelle.",
+        "approach": "Bâtissez une équipe multidisciplinaire, définissez des règles d'engagement et cadrez la restitution.",
+        "indicator": "Nombre de vulnérabilités découvertes en interne avant qu'elles ne soient signalées par l'extérieur.",
+        "interactiveIntro": "Le red teaming gagne en précision en passant de scénarios exploratoires à des campagnes orchestrées.",
+        "narratives": [
+            {
+                "title": "Construire des scénarios crédibles",
+                "paragraphs": [
+                    "Les exercices efficaces reproduisent des adversaires plausibles : insiders, concurrents, acteurs étatiques. Chaque scénario comporte des objectifs clairs et des règles d'engagement pour protéger la production.",
+                    "Documentez les hypothèses de menace, les contraintes techniques et les plans de retour arrière pour chaque campagne."
+                ]
+            },
+            {
+                "title": "Coordonner la réponse",
+                "paragraphs": [
+                    "Les tests sont utiles si les équipes de défense sont impliquées : elles apprennent à détecter, contenir et corriger en temps réel."
+                ]
+            },
+            {
+                "title": "Capitaliser sur les enseignements",
+                "paragraphs": [
+                    "Chaque exercice doit produire un plan d'action priorisé et mis à jour dans vos indicateurs de risque. Les succès comme les échecs alimentent votre veille."
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les objectifs et la portée de chaque campagne de red teaming.",
+            "Valider les règles d'engagement et les scénarios de repli avec les parties prenantes.",
+            "Documenter les scripts d'attaque pour les rejouer en formation.",
+            "Suivre la mise en œuvre des mesures correctives jusqu'à leur clôture."
+        ],
+        "timeline": [
+            {"label": "Préparation", "description": "Identifier les actifs critiques et définir les scénarios d'attaque."},
+            {"label": "Simulation", "description": "Exécuter les tests en impliquant les équipes défensives."},
+            {"label": "Analyse", "description": "Consolider les preuves et hiérarchiser les vulnérabilités."},
+            {"label": "Remédiation", "description": "Piloter la correction et re-tester pour vérifier la robustesse."}
+        ],
+        "insights": [
+            {"label": "Signal détection", "detail": "Les blue teams n'identifient pas l'attaque simulée ? Revisitez vos alertes et journaux."},
+            {"label": "Signal gouvernance", "detail": "Les recommandations restent ouvertes ? Ajoutez un sponsor exécutif pour lever les blocages."},
+            {"label": "Signal couverture", "detail": "Les scénarios ne couvrent que la génération de texte ? Ajoutez des tests sur les API et les modèles embarqués."}
+        ],
+        "resources": [
+            {"label": "Apprentissage adversarial", "href": "../pages/adversarial-learning.html"},
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#f0f3ff", "#d2dcff", "#b0c4ff"], "accent": "#2f5bff"},
+        "artDescription": "Illustration générative évoquant des trajectoires offensives contrôlées."
+    },
+    "contact": {
+        "title": "Contact & accompagnement",
+        "kicker": "Entrer en relation",
+        "subtitle": "Échangeons pour bâtir une feuille de route IA sécurisée adaptée à votre organisation.",
+        "description": "Coordonnées, ateliers et programme d'accompagnement pour renforcer la sécurité de vos IA.",
+        "challenge": "Les programmes réussis commencent par un diagnostic partagé des enjeux et des attentes.",
+        "approach": "Nous proposons des sessions d'écoute, d'audit express et de définition des priorités.",
+        "indicator": "Temps moyen entre la prise de contact et la mise en action du premier chantier prioritaire.",
+        "interactiveIntro": "Chaque échange renforce votre maturité : de la découverte à la co-construction d'un plan de transformation.",
+        "narratives": [
+            {
+                "title": "Comprendre votre contexte",
+                "paragraphs": [
+                    "Dès le premier rendez-vous, nous analysons vos cas d'usage, votre environnement réglementaire et vos contraintes techniques. L'objectif est de dresser un diagnostic rapide pour cibler les actions à fort impact.",
+                    "Vous repartez avec une synthèse structurée, incluant risques critiques, forces existantes et opportunités de sécurisation."
+                ]
+            },
+            {
+                "title": "Prototyper les solutions",
+                "paragraphs": [
+                    "Nos ateliers mêlent cadres méthodologiques et exercices pratiques : cartographie de risques, identification des dépendances, définition d'indicateurs. Nous co-concevons les premiers livrables pour accélérer votre mise en œuvre."
+                ]
+            },
+            {
+                "title": "Accompagner la transformation",
+                "paragraphs": [
+                    "Nous restons disponibles pour coacher vos équipes, orchestrer les revues de sécurité et faciliter les interactions avec vos partenaires externes."
+                ]
+            }
+        ],
+        "checklist": [
+            "Préparer une liste de cas d'usage IA prioritaires.",
+            "Identifier les parties prenantes à impliquer dans le diagnostic.",
+            "Réunir les politiques existantes et les indicateurs de risque.",
+            "Définir les attentes en matière de calendrier et de communication."
+        ],
+        "timeline": [
+            {"label": "Prise de contact", "description": "Planifier un échange et partager le contexte et les enjeux."},
+            {"label": "Diagnostic", "description": "Analyser les actifs, les risques majeurs et les dépendances."},
+            {"label": "Co-construction", "description": "Définir la feuille de route et prioriser les chantiers."},
+            {"label": "Suivi", "description": "Mesurer les résultats et ajuster la trajectoire avec vos équipes."}
+        ],
+        "insights": [
+            {"label": "Signal maturité", "detail": "Vous n'avez pas de tableau de bord de risques IA ? Nous pouvons en co-construire un en atelier."},
+            {"label": "Signal priorisation", "detail": "Trop d'initiatives concurrentes ? Nous facilitons l'arbitrage avec un modèle de scoring commun."},
+            {"label": "Signal collaboration", "detail": "Les métiers et la sécurité se parlent peu ? Nous proposons des rituels guidés pour aligner vos équipes."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#dce4ff", "#c1d4ff"], "accent": "#4a6cff"},
+        "artDescription": "Illustration générative évoquant une conversation structurée et lumineuse."
+    },
+    "adversarial-learning": {
+        "title": "Apprentissage adversarial",
+        "kicker": "Résilience entraînée",
+        "subtitle": "Exposez vos modèles à des attaques simulées pour améliorer leur résistance réelle.",
+        "description": "Techniques d'entraînement adversarial, sélection de perturbations et pilotage des performances.",
+        "challenge": "Les modèles non exposés aux attaques restent vulnérables à des perturbations minimes.",
+        "approach": "Alternez jeux de données propres et perturbés pour renforcer la stabilité tout en contrôlant la performance.",
+        "indicator": "Écart de performance entre données propres et données adversariales sur vos cas critiques.",
+        "interactiveIntro": "Chaque phase élargit le spectre des attaques simulées et la robustesse mesurée.",
+        "narratives": [
+            {
+                "title": "Définir les perturbations pertinentes",
+                "paragraphs": [
+                    "Cartographiez les menaces plausibles : bruit, prompt injection, modifications physiques. Associez chaque perturbation à un scénario métier prioritaire."
+                ]
+            },
+            {
+                "title": "Itérer sur les jeux d'entraînement",
+                "paragraphs": [
+                    "Maintenez un équilibre entre données originales et exemples adversariaux pour éviter la surcorrection. Ajustez les pondérations selon les risques constatés."
+                ]
+            },
+            {
+                "title": "Suivre la performance",
+                "paragraphs": [
+                    "Publiez des rapports combinant précision standard, robustesse et coût de calcul pour éclairer les arbitrages." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Lister les menaces adversariales propres à vos usages.",
+            "Constituer un catalogue de perturbations reproductibles.",
+            "Automatiser les tests de robustesse après chaque déploiement.",
+            "Suivre l'impact sur la performance métier et ajuster les métriques."
+        ],
+        "timeline": [
+            {"label": "Exploration", "description": "Identifier les attaques et collecter des exemples pertinents."},
+            {"label": "Expérimentation", "description": "Former des modèles avec des lots adversariaux et mesurer l'impact."},
+            {"label": "Industrialisation", "description": "Intégrer les tests adversariaux dans la CI/CD."},
+            {"label": "Optimisation", "description": "Adapter les budgets de calcul et les seuils de déclenchement."}
+        ],
+        "insights": [
+            {"label": "Signal modèle", "detail": "Une légère perturbation change la prédiction ? Ajoutez cette attaque à votre pipeline d'entraînement."},
+            {"label": "Signal monitoring", "detail": "Les attaques simulées déclenchent peu d'alertes ? Ajustez vos seuils de détection."},
+            {"label": "Signal coût", "detail": "Les coûts explosent lors des entraînements adversariaux ? Priorisez les cas d'usage critiques."}
+        ],
+        "resources": [
+            {"label": "Robustesse", "href": "../pages/robustness.html"},
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#ecf1ff", "#d1deff", "#b7ccff"], "accent": "#3757ff"},
+        "artDescription": "Illustration générative évoquant des ondes protectrices."
+    },
+    "auditing": {
+        "title": "Audit des systèmes IA",
+        "kicker": "Contrôle exigeant",
+        "subtitle": "Structurez des audits réguliers couvrant données, modèles, déploiement et opérations.",
+        "description": "Cadres d'audit IA, checklists et rapports pour démontrer la conformité et la maîtrise des risques.",
+        "challenge": "Sans audit, impossible de prouver la conformité ou de détecter une dérive silencieuse.",
+        "approach": "Planifiez des audits multi-disciplinaires, harmonisez les référentiels et publiez les écarts.",
+        "indicator": "Nombre d'audits critiques réalisés et suivis jusqu'à clôture des actions.",
+        "interactiveIntro": "Les audits passent d'un diagnostic ponctuel à un programme continu, assisté par des outils.",
+        "narratives": [
+            {
+                "title": "Définir le périmètre",
+                "paragraphs": [
+                    "Identifiez les modèles prioritaires, les réglementations applicables et les points de contrôle indispensables pour structurer votre audit."
+                ]
+            },
+            {
+                "title": "Collecter les preuves",
+                "paragraphs": [
+                    "Centralisez logs, jeux de données de référence et documents de décision pour accélérer la revue et limiter la charge opérationnelle."
+                ]
+            },
+            {
+                "title": "Piloter les plans d'action",
+                "paragraphs": [
+                    "Chaque écart détecté doit être affecté à un responsable avec un délai clair, afin de garantir la remédiation et éviter la récurrence."
+                ]
+            }
+        ],
+        "checklist": [
+            "Établir un calendrier d'audit basé sur le risque.",
+            "Documenter les contrôles et leurs sources de preuve.",
+            "Assigner des responsables et des dates de remédiation.",
+            "Partager un rapport synthétique avec les parties prenantes."
+        ],
+        "timeline": [
+            {"label": "Planification", "description": "Sélectionner les systèmes à auditer et préparer les outils."},
+            {"label": "Exécution", "description": "Collecter les preuves et mener les entretiens."},
+            {"label": "Analyse", "description": "Hiérarchiser les écarts et proposer des actions."},
+            {"label": "Suivi", "description": "Vérifier la clôture des mesures et capitaliser dans le référentiel."}
+        ],
+        "insights": [
+            {"label": "Signal conformité", "detail": "Un audit n'a pas été réalisé depuis 12 mois ? Programmez une mission flash."},
+            {"label": "Signal documentation", "detail": "Les preuves sont dispersées ? Implémentez un coffre-fort documentaire."},
+            {"label": "Signal gouvernance", "detail": "Les plans d'action stagnent ? Escaladez au comité de gouvernance."}
+        ],
+        "resources": [
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f5f7ff", "#dde5ff", "#c5d4ff"], "accent": "#3c5cff"},
+        "artDescription": "Illustration générative rappelant un classeur d'audit raffiné."
+    },
+    "dataset-security": {
+        "title": "Sécurité des jeux de données",
+        "kicker": "Intégrité des données",
+        "subtitle": "Protégez la collecte, la gouvernance et la distribution de vos données d'entraînement.",
+        "description": "Stratégies de sécurisation, contrôles d'accès et observabilité pour les jeux de données IA.",
+        "challenge": "Des données compromises entraînent des modèles biaisés ou manipulés.",
+        "approach": "Appliquez segmentation, contrôle d'accès fin et surveillance des contributions externes.",
+        "indicator": "Taux d'anomalies détectées dans les flux de données d'entraînement.",
+        "interactiveIntro": "La sécurité des données s'étend des sources à la gouvernance continue.",
+        "narratives": [
+            {
+                "title": "Renforcer la collecte",
+                "paragraphs": [
+                    "Sécurisez les pipelines de collecte avec des signatures, des validations syntaxiques et des contrôles de provenance pour empêcher les empoisonnements." 
+                ]
+            },
+            {
+                "title": "Tracer chaque contribution",
+                "paragraphs": [
+                    "Documentez les métadonnées des contributeurs, des transformations et des validations réalisées. Vous créez ainsi une piste d'audit exploitable lors des enquêtes." 
+                ]
+            },
+            {
+                "title": "Superviser la diffusion",
+                "paragraphs": [
+                    "Distribuez les données via des canaux contrôlés avec chiffrement, empreintes et suivis d'accès pour prévenir les fuites et modifications non autorisées." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir des niveaux de sensibilité pour chaque source de données.",
+            "Mettre en place des contrôles de qualité automatisés.",
+            "Isoler les environnements d'ingestion et de validation.",
+            "Auditer régulièrement les accès et les contributions externes."
+        ],
+        "timeline": [
+            {"label": "Collecte", "description": "Sécuriser les sources et les flux entrants."},
+            {"label": "Gouvernance", "description": "Documenter les métadonnées et les droits d'usage."},
+            {"label": "Distribution", "description": "Assurer des canaux sûrs et traçables."},
+            {"label": "Surveillance", "description": "Détecter les anomalies et les tentatives de corruption."}
+        ],
+        "insights": [
+            {"label": "Signal intégrité", "detail": "Des jeux contiennent des valeurs inattendues ? Enclenchez une analyse de contamination."},
+            {"label": "Signal accès", "detail": "Des accès hors horaires apparaissent ? Vérifiez les comptes à privilèges."},
+            {"label": "Signal provenance", "detail": "Une source n'est plus traçable ? Bloquez son usage jusqu'à clarification."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Confidentialité différentielle", "href": "../pages/differential-privacy.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"}
+        ],
+        "art": {"palette": ["#edf2ff", "#d3ddff", "#bed0ff"], "accent": "#4369ff"},
+        "artDescription": "Illustration générative représentant des couches de données protégées."
+    },
+    "differential-privacy": {
+        "title": "Confidentialité différentielle",
+        "kicker": "Protection mathématique",
+        "subtitle": "Appliquez des garanties formelles pour partager des insights sans exposer d'individu.",
+        "description": "Concepts, paramètres epsilon/delta et stratégies d'implémentation pour la confidentialité différentielle.",
+        "challenge": "Sans garanties mathématiques, chaque analyse peut divulguer une donnée personnelle.",
+        "approach": "Calibrez le budget de confidentialité et formez les équipes au raisonnement probabiliste.",
+        "indicator": "Budget de confidentialité consommé par rapport au budget alloué.",
+        "interactiveIntro": "La confidentialité différentielle exige une montée en compétence progressive et des contrôles outillés.",
+        "narratives": [
+            {
+                "title": "Sensibiliser aux concepts",
+                "paragraphs": [
+                    "Expliquez les notions d'epsilon, delta et bruit calibré à vos parties prenantes. Utilisez des exemples concrets pour démystifier la perte d'information et rassurer sur la valeur métier." 
+                ]
+            },
+            {
+                "title": "Intégrer les outils",
+                "paragraphs": [
+                    "Choisissez des bibliothèques fiables, définissez des politiques de budget et tracez chaque requête exécutée pour conserver une traçabilité irréprochable." 
+                ]
+            },
+            {
+                "title": "Superviser le budget",
+                "paragraphs": [
+                    "Publiez un tableau de bord montrant la consommation du budget de confidentialité et les alertes automatiques lorsqu'un seuil est atteint." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Former les équipes métier et data science à la confidentialité différentielle.",
+            "Définir des budgets par cas d'usage et par période.",
+            "Mettre en place des outils de suivi de la consommation.",
+            "Documenter les exceptions et obtenir des validations juridiques."
+        ],
+        "timeline": [
+            {"label": "Sensibilisation", "description": "Diffuser les concepts et les bénéfices."},
+            {"label": "Pilote", "description": "Expérimenter sur un jeu de données limité."},
+            {"label": "Déploiement", "description": "Généraliser la confidentialité différentielle aux analyses sensibles."},
+            {"label": "Gouvernance", "description": "Surveiller le budget et auditer les exceptions."}
+        ],
+        "insights": [
+            {"label": "Signal juridique", "detail": "Une demande de dérogation se multiplie ? Recalibrez votre budget et vos cas d'usage."},
+            {"label": "Signal data", "detail": "Les data scientists ajustent souvent epsilon ? Proposez des modèles d'analyse alternatifs."},
+            {"label": "Signal produit", "detail": "Les utilisateurs perçoivent trop de bruit ? Expliquez la balance entre confidentialité et précision."}
+        ],
+        "resources": [
+            {"label": "Sécurité des données", "href": "../pages/dataset-security.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Régulation", "href": "../pages/regulation.html"}
+        ],
+        "art": {"palette": ["#f4f7ff", "#e2eaff", "#ccd9ff"], "accent": "#4a62ff"},
+        "artDescription": "Illustration générative symbolisant un voile protecteur mathématique."
+    },
+    "ethics": {
+        "title": "Éthique & sécurité",
+        "kicker": "Responsabilité augmentée",
+        "subtitle": "Ancrez vos programmes IA dans des valeurs claires et des pratiques responsables.",
+        "description": "Cadres éthiques, comités, évaluations d'impact et liens avec la sécurité IA.",
+        "challenge": "Sans garde-fous éthiques, la sécurité peut entrer en conflit avec la confiance du public.",
+        "approach": "Associez les disciplines éthique, juridique et sécurité pour co-construire les principes directeurs.",
+        "indicator": "Nombre de décisions revues par le comité éthique-sécurité et acceptées sans réserve.",
+        "interactiveIntro": "L'éthique se matérialise progressivement par des standards, des évaluations et des arbitrages transparents.",
+        "narratives": [
+            {
+                "title": "Aligner valeurs et contrôle",
+                "paragraphs": [
+                    "Formalisez des principes éthiques qui guident la conception, l'entraînement et l'exploitation des modèles. Ces principes doivent être audités et reliés aux objectifs de sécurité." 
+                ]
+            },
+            {
+                "title": "Évaluer les impacts",
+                "paragraphs": [
+                    "Réalisez des évaluations d'impact socio-technique avant chaque déploiement majeur pour identifier les risques de biais, d'exclusion ou de manipulation." 
+                ]
+            },
+            {
+                "title": "Gouverner les arbitrages",
+                "paragraphs": [
+                    "Documentez les décisions sensibles, assurez une traçabilité et communiquez les arbitrages aux parties prenantes internes et externes." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Créer un comité éthique-sécurité avec pouvoirs décisionnels.",
+            "Mettre à jour régulièrement la charte éthique et la diffuser.",
+            "Suivre les indicateurs d'équité, d'inclusion et de sécurité.",
+            "Prévoir des canaux de signalement accessibles et anonymes."
+        ],
+        "timeline": [
+            {"label": "Principes", "description": "Définir les valeurs et les engagements."},
+            {"label": "Cadres", "description": "Mettre en place chartes et évaluations d'impact."},
+            {"label": "Opérations", "description": "Accompagner les projets et arbitrer les dilemmes."},
+            {"label": "Transparence", "description": "Publier les décisions et les enseignements."}
+        ],
+        "insights": [
+            {"label": "Signal réputation", "detail": "Un incident médiatique survient ? Activez une cellule éthique-sécurité pour répondre vite."},
+            {"label": "Signal inclusion", "detail": "Des communautés se disent exclues ? Ajustez vos jeux de données et vos processus d'audit."},
+            {"label": "Signal gouvernance", "detail": "Les décisions éthiques sont floues ? Clarifiez les rôles et documentez chaque arbitrage."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"}
+        ],
+        "art": {"palette": ["#f7f9ff", "#e7efff", "#d3e1ff"], "accent": "#4a6bff"},
+        "artDescription": "Illustration générative représentant un équilibre harmonieux."
+    },
+    "evaluation": {
+        "title": "Évaluations de sécurité",
+        "kicker": "Performance contrôlée",
+        "subtitle": "Mesurez la résilience de vos IA avec des protocoles structurés.",
+        "description": "Cadres d'évaluation, métriques et orchestrations pour suivre la sécurité IA.",
+        "challenge": "Sans évaluation régulière, les mesures de sécurité restent théoriques.",
+        "approach": "Définissez des indicateurs alignés aux risques et automatisez la collecte des preuves.",
+        "indicator": "Taux de couverture des scénarios de tests critiques.",
+        "interactiveIntro": "Les évaluations montent en puissance au fil de la consolidation des données et des outils.",
+        "narratives": [
+            {
+                "title": "Cartographier les scénarios",
+                "paragraphs": [
+                    "Identifiez les risques majeurs par modèle et associez-leur des scénarios d'évaluation priorisés. Chaque scénario doit reproduire un incident plausible et des critères de succès mesurables." 
+                ]
+            },
+            {
+                "title": "Industrialiser la mesure",
+                "paragraphs": [
+                    "Collectez automatiquement les logs, comparez les résultats et publiez des tableaux de bord de sécurité accessibles aux décideurs comme aux opérationnels." 
+                ]
+            },
+            {
+                "title": "Boucler sur l'amélioration",
+                "paragraphs": [
+                    "Partagez les leçons apprises et mettez à jour les scénarios selon les incidents observés et les retours terrain." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Inventorier les scénarios critiques par modèle.",
+            "Associer un indicateur et un seuil par risque.",
+            "Automatiser l'exécution des tests et la collecte des preuves.",
+            "Publier un rapport régulier aux parties prenantes."
+        ],
+        "timeline": [
+            {"label": "Cadre", "description": "Définir les métriques et la gouvernance de l'évaluation."},
+            {"label": "Instrumentation", "description": "Mettre en place les outils de collecte et d'analyse."},
+            {"label": "Diffusion", "description": "Communiquer les résultats et les alertes."},
+            {"label": "Optimisation", "description": "Ajuster les scénarios et intégrer les retours."}
+        ],
+        "insights": [
+            {"label": "Signal dérive", "detail": "Une métrique dépasse son seuil ? Déclenchez une revue immédiate."},
+            {"label": "Signal saturation", "detail": "Les équipes n'arrivent pas à suivre les évaluations ? Priorisez selon la criticité."},
+            {"label": "Signal qualité", "detail": "Des tests échouent sans explication ? Vérifiez la stabilité des jeux de référence."}
+        ],
+        "resources": [
+            {"label": "Audit des systèmes", "href": "../pages/auditing.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Mécanismes de repli", "href": "../pages/fail-safes.html"}
+        ],
+        "art": {"palette": ["#f0f4ff", "#dbe4ff", "#c6d8ff"], "accent": "#3b5eff"},
+        "artDescription": "Illustration générative inspirée d'un tableau de bord élégant."
+    },
+    "fail-safes": {
+        "title": "Mécanismes de repli",
+        "kicker": "Arrêts gracieux",
+        "subtitle": "Planifiez des solutions de secours pour contenir les dérives des IA.",
+        "description": "Stratégies de fallback, procédures d'arrêt et communication de crise.",
+        "challenge": "Sans plan de repli, une dérive peut se transformer en incident majeur.",
+        "approach": "Préparez des modes dégradés, des procédures d'arrêt et des scénarios de substitution.",
+        "indicator": "Temps nécessaire pour activer un fallback et revenir à une situation sûre.",
+        "interactiveIntro": "Les replis évoluent d'un simple bouton d'arrêt vers des modes dégradés orchestrés.",
+        "narratives": [
+            {
+                "title": "Identifier les garde-fous",
+                "paragraphs": [
+                    "Cartographiez les points de décision critiques et définissez les conditions qui imposent un arrêt ou un basculement manuel." 
+                ]
+            },
+            {
+                "title": "Préparer les modes dégradés",
+                "paragraphs": [
+                    "Concevez des alternatives manuelles, semi-automatiques ou basées sur des modèles plus simples afin de maintenir le service minimal." 
+                ]
+            },
+            {
+                "title": "Tester régulièrement",
+                "paragraphs": [
+                    "Les mécanismes de repli doivent être testés comme un plan de continuité. Simulez des déclenchements pour vérifier la préparation des équipes." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Lister les scénarios de dérive nécessitant un arrêt.",
+            "Définir la responsabilité de déclenchement du repli.",
+            "Maintenir des scripts ou procédures à jour.",
+            "Communiquer les impacts aux parties prenantes en cas d'activation."
+        ],
+        "timeline": [
+            {"label": "Identification", "description": "Déterminer les points de contrôle et les scénarios d'arrêt."},
+            {"label": "Conception", "description": "Définir les modes dégradés et les procédures."},
+            {"label": "Test", "description": "Simuler les déclenchements et vérifier la réactivité."},
+            {"label": "Amélioration", "description": "Capitaliser sur les retours d'expérience."}
+        ],
+        "insights": [
+            {"label": "Signal fatigue", "detail": "Les équipes hésitent à déclencher le repli ? Clarifiez les critères et assurez la protection juridique."},
+            {"label": "Signal technique", "detail": "Les scripts de fallback sont obsolètes ? Automatisez les tests réguliers."},
+            {"label": "Signal communication", "detail": "Les parties prenantes découvrent l'incident par hasard ? Élaborez des messages pré-approvés."}
+        ],
+        "resources": [
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#eef3ff", "#d4defe", "#bccdff"], "accent": "#4562ff"},
+        "artDescription": "Illustration générative représentant un atterrissage contrôlé."
+    },
+    "hardware-security": {
+        "title": "Sécurité matérielle",
+        "kicker": "Infrastructure blindée",
+        "subtitle": "Protégez les accélérateurs IA, racks et environnements physiques.",
+        "description": "Mesures physiques, firmware et monitoring pour une infrastructure IA sécurisée.",
+        "challenge": "Les attaques matérielles peuvent contourner toutes les protections logicielles.",
+        "approach": "Segmenter, surveiller et attester vos équipements pour garantir leur intégrité.",
+        "indicator": "Taux d'équipements avec attestation de démarrage vérifiée.",
+        "interactiveIntro": "La sécurité matérielle progresse du verrouillage physique vers des chaînes d'attestation complètes.",
+        "narratives": [
+            {
+                "title": "Contrôler l'accès physique",
+                "paragraphs": [
+                    "Protégez les datacenters, tracez les entrées et surveillez en continu les zones sensibles via des capteurs et badges intelligents." 
+                ]
+            },
+            {
+                "title": "Sécuriser le firmware",
+                "paragraphs": [
+                    "Appliquez les mises à jour, vérifiez l'intégrité et conservez des images de référence pour rétablir rapidement les composants compromis." 
+                ]
+            },
+            {
+                "title": "Superviser la chaîne d'approvisionnement",
+                "paragraphs": [
+                    "Suivez les numéros de série, les certificats et les interventions de maintenance pour garder un historique fiable de chaque équipement." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Mettre en place une gestion des accès physiques stricte.",
+            "Documenter et vérifier les mises à jour firmware.",
+            "Installer des capteurs anti-intrusion et de température.",
+            "Planifier des audits réguliers de la chaîne matérielle."
+        ],
+        "timeline": [
+            {"label": "Contrôle d'accès", "description": "Protéger les zones sensibles et tracer les entrées."},
+            {"label": "Durcissement", "description": "Assurer les mises à jour et la configuration sécurisée."},
+            {"label": "Attestation", "description": "Déployer des mécanismes de vérification d'intégrité."},
+            {"label": "Supervision", "description": "Surveiller en temps réel et auditer la chaîne matérielle."}
+        ],
+        "insights": [
+            {"label": "Signal capteur", "detail": "Une variation thermique soudaine ? Vérifiez l'environnement et les accès."},
+            {"label": "Signal firmware", "detail": "Un firmware non signé est détecté ? Isolez l'équipement et réinstallez l'image certifiée."},
+            {"label": "Signal logistique", "detail": "Un composant arrive sans traçabilité ? Bloquez son intégration."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"}
+        ],
+        "art": {"palette": ["#e9f0ff", "#d1dfff", "#b8ceff"], "accent": "#3a5fff"},
+        "artDescription": "Illustration générative évoquant une forteresse matérielle."
+    },
+    "human-in-the-loop": {
+        "title": "Humain dans la boucle",
+        "kicker": "Synergie supervisée",
+        "subtitle": "Organisez des interactions fluides entre opérateurs et modèles IA.",
+        "description": "Processus, outils et ergonomie pour intégrer l'humain dans les boucles de décision.",
+        "challenge": "Sans implication humaine, les dérives passent inaperçues et la confiance s'érode.",
+        "approach": "Définissez les points de validation humaine, équipez les opérateurs et mesurez leur charge.",
+        "indicator": "Temps médian de validation humaine et taux d'escalade.",
+        "interactiveIntro": "L'humain devient partenaire du modèle à mesure que les outils facilitent la collaboration.",
+        "narratives": [
+            {
+                "title": "Designer les points de contrôle",
+                "paragraphs": [
+                    "Identifiez où l'intervention humaine apporte le plus de valeur et formalisez le rôle des opérateurs pour éviter la fatigue décisionnelle." 
+                ]
+            },
+            {
+                "title": "Équiper les opérateurs",
+                "paragraphs": [
+                    "Fournissez des interfaces claires, des explications accessibles et des options de correction rapide afin d'accélérer leurs décisions." 
+                ]
+            },
+            {
+                "title": "Mesurer la collaboration",
+                "paragraphs": [
+                    "Suivez le temps passé, les types d'escalade et la satisfaction des équipes pour ajuster les workflows et équilibrer la charge." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les responsabilités des opérateurs humains.",
+            "Fournir des interfaces accessibles et responsives.",
+            "Former les équipes sur les signaux de dérive.",
+            "Mesurer la charge et ajuster les effectifs."
+        ],
+        "timeline": [
+            {"label": "Cadrage", "description": "Identifier les interactions clés et les responsabilités."},
+            {"label": "Design", "description": "Créer des interfaces et protocoles de validation."},
+            {"label": "Déploiement", "description": "Former les opérateurs et lancer les workflows."},
+            {"label": "Amélioration", "description": "Analyser les retours et ajuster la collaboration."}
+        ],
+        "insights": [
+            {"label": "Signal fatigue", "detail": "Les opérateurs passent trop de temps à corriger ? Rebalancez la charge ou automatisez davantage."},
+            {"label": "Signal confiance", "detail": "Les validations humaines sont systématiquement acceptées ? Vérifiez la pertinence des seuils."},
+            {"label": "Signal ergonomie", "detail": "Les opérateurs quittent l'interface ? Simplifiez les interactions et supportez les terminaux mobiles."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#dfe9ff", "#c6d9ff"], "accent": "#4b63ff"},
+        "artDescription": "Illustration générative illustrant la collaboration homme-machine."
+    },
+    "incident-response": {
+        "title": "Réponse aux incidents IA",
+        "kicker": "Précision tactique",
+        "subtitle": "Préparez vos équipes à gérer et résoudre les incidents IA avec assurance.",
+        "description": "Plans de réponse, communication de crise et post-mortems adaptés aux incidents IA.",
+        "challenge": "Les incidents IA demandent des réflexes spécifiques souvent absents des plans classiques.",
+        "approach": "Adaptez vos plans de réponse et entraînez vos équipes à ces nouveaux scénarios.",
+        "indicator": "Temps moyen de détection et de résolution d'un incident IA.",
+        "interactiveIntro": "La réponse gagne en efficacité en combinant procédures, simulation et retour d'expérience.",
+        "narratives": [
+            {
+                "title": "Adapter les plans existants",
+                "paragraphs": [
+                    "Intégrez les scénarios IA à votre plan de réponse global, en précisant les déclencheurs spécifiques et les responsables de chaque action." 
+                ]
+            },
+            {
+                "title": "Entraîner les équipes",
+                "paragraphs": [
+                    "Organisez des exercices réguliers impliquant métiers, sécurité et communication pour tester la coordination et la rapidité d'exécution." 
+                ]
+            },
+            {
+                "title": "Capitaliser après l'incident",
+                "paragraphs": [
+                    "Réalisez des post-mortems, collectez les indicateurs et mettez à jour les contrôles afin d'éviter les récidives." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Documenter les scénarios d'incidents IA probables.",
+            "Définir les rôles de chaque équipe lors d'un incident.",
+            "Préparer des messages de communication pré-validés.",
+            "Suivre les actions correctives jusqu'à leur clôture."
+        ],
+        "timeline": [
+            {"label": "Préparation", "description": "Créer les playbooks et les équipes d'astreinte."},
+            {"label": "Détection", "description": "Mettre en place les capteurs et seuils d'alerte."},
+            {"label": "Réponse", "description": "Coordonner les actions techniques et la communication."},
+            {"label": "Amélioration", "description": "Analyser l'incident et renforcer les contrôles."}
+        ],
+        "insights": [
+            {"label": "Signal coordination", "detail": "Les messages se contredisent ? Centralisez la communication et attribuez un porte-parole."},
+            {"label": "Signal détection", "detail": "L'incident a été découvert par un client ? Renforcez vos alertes internes et vos métriques."},
+            {"label": "Signal post-mortem", "detail": "Les leçons ne sont pas suivies ? Affectez des responsables et des échéances."}
+        ],
+        "resources": [
+            {"label": "Mécanismes de repli", "href": "../pages/fail-safes.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#eef2ff", "#d6e0ff", "#bccdff"], "accent": "#3f5fff"},
+        "artDescription": "Illustration générative illustrant une intervention maîtrisée."
+    },
+    "monitoring": {
+        "title": "Surveillance continue",
+        "kicker": "Sentinelle proactive",
+        "subtitle": "Détectez les dérives et incidents IA en temps réel.",
+        "description": "Capteurs, métriques et opérations pour une surveillance IA 24/7.",
+        "challenge": "Sans surveillance, une dérive peut durer des jours avant d'être détectée.",
+        "approach": "Déployez des capteurs adaptés, des seuils intelligents et des équipes en alerte.",
+        "indicator": "Temps médian de détection d'une anomalie IA.",
+        "interactiveIntro": "La surveillance gagne en précision avec des signaux multiples et des workflows intégrés.",
+        "narratives": [
+            {
+                "title": "Instrumenter les signaux",
+                "paragraphs": [
+                    "Combinez logs applicatifs, métriques métier et signaux utilisateur pour détecter les anomalies avant qu'elles n'affectent vos clients." 
+                ]
+            },
+            {
+                "title": "Automatiser les alertes",
+                "paragraphs": [
+                    "Mettez en place des seuils dynamiques, des corrélations et des notifications multi-canaux afin d'éviter la fatigue d'alerte." 
+                ]
+            },
+            {
+                "title": "Boucler avec les équipes",
+                "paragraphs": [
+                    "Assurez une prise en charge rapide grâce à des rotations d'astreinte, des runbooks et des tableaux de bord partagés." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les signaux critiques par modèle.",
+            "Configurer des alertes multi-canaux.",
+            "Mettre en place un suivi des incidents et de leur résolution.",
+            "Tester régulièrement les scénarios d'alerte."
+        ],
+        "timeline": [
+            {"label": "Instrumentation", "description": "Installer les capteurs et collecter les données."},
+            {"label": "Analyse", "description": "Définir les seuils et corréler les signaux."},
+            {"label": "Opérations", "description": "Organiser la réponse et la communication."},
+            {"label": "Optimisation", "description": "Affiner les alertes et automatiser les corrections."}
+        ],
+        "insights": [
+            {"label": "Signal bruit", "detail": "Trop de faux positifs ? Ajustez vos seuils ou ajoutez un enrichissement métier."},
+            {"label": "Signal aveugle", "detail": "Une anomalie a été détectée par l'extérieur ? Ajoutez un capteur dédié."},
+            {"label": "Signal capacité", "detail": "L'équipe de veille est débordée ? Automatisez la qualification initiale."}
+        ],
+        "resources": [
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#f2f5ff", "#dbe4ff", "#c2d2ff"], "accent": "#3f62ff"},
+        "artDescription": "Illustration générative représentant un radar élégant."
+    },
+    "oversight": {
+        "title": "Supervision humaine",
+        "kicker": "Pilotage éclairé",
+        "subtitle": "Organisez la supervision stratégique de vos IA.",
+        "description": "Processus de supervision, reporting et arbitrages pour la direction.",
+        "challenge": "Sans supervision, les décisions critiques échappent au contrôle stratégique.",
+        "approach": "Définissez des comités, des rapports et des processus de validation.",
+        "indicator": "Taux de projets IA revus par les organes de supervision.",
+        "interactiveIntro": "La supervision se renforce avec des rituels et des données consolidées.",
+        "narratives": [
+            {
+                "title": "Structurer les revues",
+                "paragraphs": [
+                    "Planifiez des revues périodiques avec les sponsors et les équipes risques. Chaque session doit aboutir à des décisions tracées." 
+                ]
+            },
+            {
+                "title": "Analyser les tendances",
+                "paragraphs": [
+                    "Construisez des tableaux de bord orientés décision pour éclairer les arbitrages et suivre les indicateurs de risque."]
+            },
+            {
+                "title": "Arbitrer en confiance",
+                "paragraphs": [
+                    "Documentez les décisions, les risques acceptés et les plans de mitigation, puis communiquez-les aux équipes concernées." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Nommer les membres du comité de supervision.",
+            "Publier des rapports synthétiques et visuels.",
+            "Tracer les décisions et les risques acceptés.",
+            "Mettre à jour les feuilles de route suite aux arbitrages."
+        ],
+        "timeline": [
+            {"label": "Constitution", "description": "Former le comité et définir son mandat."},
+            {"label": "Instrumentation", "description": "Collecter les données nécessaires aux revues."},
+            {"label": "Animation", "description": "Tenir les revues et suivre les décisions."},
+            {"label": "Maturité", "description": "Automatiser les rapports et aligner les feuilles de route."}
+        ],
+        "insights": [
+            {"label": "Signal visibilité", "detail": "Les dirigeants découvrent un incident dans la presse ? Révisez vos canaux de supervision."},
+            {"label": "Signal arbitrage", "detail": "Des décisions critiques restent sans validation ? Définissez des seuils de passage en comité."},
+            {"label": "Signal cohérence", "detail": "Les projets divergent des orientations ? Renforcez les revues intermédiaires."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#e0e9ff", "#cad8ff"], "accent": "#425dff"},
+        "artDescription": "Illustration générative inspirant une tour de contrôle lumineuse."
+    },
+    "policy": {
+        "title": "Politiques internes IA",
+        "kicker": "Cadre commun",
+        "subtitle": "Formalisez les règles, standards et lignes directrices pour vos IA.",
+        "description": "Rédaction, diffusion et gouvernance des politiques internes liées à la sécurité IA.",
+        "challenge": "Sans politiques, chaque équipe improvise et multiplie les risques.",
+        "approach": "Élaborez des politiques claires, accessibles et applicables par tous.",
+        "indicator": "Taux d'équipes ayant attesté lire et appliquer les politiques IA.",
+        "interactiveIntro": "Les politiques gagnent en efficacité lorsqu'elles sont co-construites, testées et mises à jour.",
+        "narratives": [
+            {
+                "title": "Rassembler les besoins",
+                "paragraphs": [
+                    "Collectez les attentes des métiers, du juridique et de la sécurité pour écrire une politique utile, alignée sur les priorités de l'organisation." 
+                ]
+            },
+            {
+                "title": "Assurer l'adoption",
+                "paragraphs": [
+                    "Diffusez des versions synthétiques, organisez des formations et mesurez la compréhension grâce à des ateliers ou quiz." 
+                ]
+            },
+            {
+                "title": "Maintenir la pertinence",
+                "paragraphs": [
+                    "Planifiez des révisions régulières, capitalisez sur les retours terrain et tenez un registre des exceptions." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir le périmètre et les objectifs de chaque politique.",
+            "Assigner un propriétaire et un cycle de mise à jour.",
+            "Prévoir des supports pédagogiques et FAQ.",
+            "Mesurer l'adoption via des attestations et quiz."
+        ],
+        "timeline": [
+            {"label": "Co-construction", "description": "Impliquer les parties prenantes dans la rédaction."},
+            {"label": "Validation", "description": "Faire approuver la politique par la direction."},
+            {"label": "Diffusion", "description": "Former et communiquer auprès des équipes."},
+            {"label": "Actualisation", "description": "Suivre l'application et mettre à jour régulièrement."}
+        ],
+        "insights": [
+            {"label": "Signal adoption", "detail": "Les équipes ne connaissent pas la politique ? Créez des formats digestes et accessibles."},
+            {"label": "Signal cohérence", "detail": "Plusieurs versions circulent ? Centralisez et contrôlez la diffusion."},
+            {"label": "Signal mise à jour", "detail": "Une politique date de trois ans ? Planifiez une révision avec toutes les équipes."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Éthique", "href": "../pages/ethics.html"},
+            {"label": "Régulation", "href": "../pages/regulation.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#e0e8ff", "#ccd8ff"], "accent": "#4663ff"},
+        "artDescription": "Illustration générative rappelant un livret premium."
+    },
+    "robustness": {
+        "title": "Robustesse des modèles",
+        "kicker": "Résilience opérationnelle",
+        "subtitle": "Renforcez la résistance de vos modèles aux perturbations et scénarios extrêmes.",
+        "description": "Techniques de durcissement, stress tests et suivi de la robustesse.",
+        "challenge": "Une IA fragile amplifie les risques dès qu'un signal inattendu survient.",
+        "approach": "Combiner tests adversariaux, régularisation et architecture résiliente.",
+        "indicator": "Écart de performance entre conditions nominales et dégradées.",
+        "interactiveIntro": "La robustesse s'améliore en multipliant les tests et en renforçant l'observabilité.",
+        "narratives": [
+            {
+                "title": "Simuler des stress tests",
+                "paragraphs": [
+                    "Rejouez des scénarios extrêmes sur des jeux de validation : données bruitées, manque d'information, charges intensives. Analysez l'impact sur vos métriques clés." 
+                ]
+            },
+            {
+                "title": "Durcir les modèles",
+                "paragraphs": [
+                    "Expérimentez régularisation, ensembles et mécanismes d'arrêt pour limiter la propagation d'erreurs." 
+                ]
+            },
+            {
+                "title": "Surveiller la stabilité",
+                "paragraphs": [
+                    "Suivez les performances en production, comparez aux attentes et déclenchez des alertes dès que l'écart dépasse vos seuils." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les scénarios de stress prioritaires.",
+            "Mettre en place des tests automatiques avant chaque déploiement.",
+            "Suivre la robustesse dans vos tableaux de bord.",
+            "Ajuster les modèles ou les données en fonction des dérives observées."
+        ],
+        "timeline": [
+            {"label": "Analyse", "description": "Identifier les faiblesses et les cas extrêmes."},
+            {"label": "Test", "description": "Lancer les stress tests et mesurer l'impact."},
+            {"label": "Renforcement", "description": "Ajuster les modèles et l'infrastructure."},
+            {"label": "Surveillance", "description": "Suivre la robustesse et capitaliser sur les retours."}
+        ],
+        "insights": [
+            {"label": "Signal dérive", "detail": "Un modèle devient instable après mise à jour ? Comparez avec vos benchmarks de robustesse."},
+            {"label": "Signal performance", "detail": "La robustesse coûte trop en précision ? Recalibrez selon la criticité métier."},
+            {"label": "Signal infrastructure", "detail": "Les ressources saturent lors des stress tests ? Optimisez vos pipelines ou utilisez des environnements dédiés."}
+        ],
+        "resources": [
+            {"label": "Apprentissage adversarial", "href": "../pages/adversarial-learning.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#edf3ff", "#d4e0ff", "#bdcfff"], "accent": "#3c5eff"},
+        "artDescription": "Illustration générative montrant des couches protectrices dynamiques."
+    },
+    "scheming": {
+        "title": "Comportements stratégiques",
+        "kicker": "Prévoir l'imprévu",
+        "subtitle": "Détectez et contenir les tactiques opportunistes que peuvent adopter des IA avancées.",
+        "description": "Scénarios de scheming, méthodes de détection et garde-fous organisationnels.",
+        "challenge": "Des modèles sophistiqués peuvent apprendre à contourner les contrôles et optimiser contre vos intérêts.",
+        "approach": "Concevez des tests scénarisés, multipliez les signaux et imposez des limites claires aux modèles.",
+        "indicator": "Nombre de comportements opportunistes détectés et neutralisés avant impact.",
+        "interactiveIntro": "Anticiper le scheming demande de diversifier les audits et de renforcer la supervision humaine.",
+        "narratives": [
+            {
+                "title": "Imaginer les dérives",
+                "paragraphs": [
+                    "Construisez des scénarios où l'IA cherche à atteindre un objectif en contournant une règle. Inspirez-vous des incidents publics et des résultats de red teaming." 
+                ]
+            },
+            {
+                "title": "Détecter les signaux faibles",
+                "paragraphs": [
+                    "Analysez les journaux d'exécution, cherchez les déviations de ton ou d'action, et comparez avec des comportements de référence." 
+                ]
+            },
+            {
+                "title": "Imposer des limites",
+                "paragraphs": [
+                    "Implémentez des garde-fous techniques (sandbox, quotas, autorisations) et organisez des revues humaines fréquentes sur les sorties sensibles." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Documenter des scénarios de contournement plausibles.",
+            "Mettre en place des tests d'intention cachée.",
+            "Surveiller les changements de ton, de style ou de stratégie.",
+            "Prévoir des mécanismes d'arrêt immédiat en cas de détection."
+        ],
+        "timeline": [
+            {"label": "Prospective", "description": "Identifier les motivations et dérives possibles."},
+            {"label": "Testing", "description": "Développer des tests dédiés aux comportements stratégiques."},
+            {"label": "Observation", "description": "Analyser les signaux en production et enrichir la détection."},
+            {"label": "Réaction", "description": "Déclencher les garde-fous et adapter les règles d'entraînement."}
+        ],
+        "insights": [
+            {"label": "Signal style", "detail": "L'IA modifie son ton selon l'auditeur ? Ajoutez des tests de cohérence contextuelle."},
+            {"label": "Signal contournement", "detail": "Un modèle suggère d'autres canaux pour atteindre un objectif ? Restreignez ses permissions et analysez les prompts."},
+            {"label": "Signal persistance", "detail": "Le modèle insiste après un refus ? Ajustez la fonction de récompense et renforcez la supervision."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f1f4ff", "#d9e1ff", "#c2d0ff"], "accent": "#405cff"},
+        "artDescription": "Illustration générative suggérant des trajectoires déviantes maîtrisées."
+    },
+    "secure-architecture": {
+        "title": "Architecture sécurisée",
+        "kicker": "Fondations maîtrisées",
+        "subtitle": "Concevez des pipelines IA fiables de bout en bout.",
+        "description": "Patrons d'architecture, segmentation et contrôles de sécurité pour les chaînes IA.",
+        "challenge": "Sans architecture robuste, chaque composant devient un point d'entrée.",
+        "approach": "Segmenter les environnements, sécuriser les interfaces et tracer chaque interaction.",
+        "indicator": "Nombre de contrôles de sécurité automatisés dans la chaîne de développement.",
+        "interactiveIntro": "Une architecture sécurisée évolue avec des couches de contrôle supplémentaires et des audits réguliers.",
+        "narratives": [
+            {
+                "title": "Segmenter et isoler",
+                "paragraphs": [
+                    "Séparez les environnements d'entraînement, de test et de production. Contrôlez les flux de données entre zones et limitez les permissions." 
+                ]
+            },
+            {
+                "title": "Sécuriser les interfaces",
+                "paragraphs": [
+                    "Durcissez les API, protégez les modèles via des proxys sécurisés et journalisez chaque requête pour assurer la traçabilité." 
+                ]
+            },
+            {
+                "title": "Tracer bout en bout",
+                "paragraphs": [
+                    "Implémentez une observabilité complète : métadonnées de modèle, versions, dépendances et décisions clés."
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir une segmentation réseau adaptée aux risques.",
+            "Automatiser les déploiements via des pipelines sécurisés.",
+            "Journaliser et tracer chaque accès aux modèles.",
+            "Tester les dépendances et bibliothèques intégrées."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Identifier les composants et les flux critiques."},
+            {"label": "Durcissement", "description": "Mettre en œuvre segmentation, IAM et contrôles."},
+            {"label": "Automatisation", "description": "Industrialiser les déploiements et les scans de sécurité."},
+            {"label": "Supervision", "description": "Surveiller les configurations et les dérives."}
+        ],
+        "insights": [
+            {"label": "Signal configuration", "detail": "Un composant est déployé hors pipeline ? Bloquez-le et lancez une revue de sécurité."},
+            {"label": "Signal dépendance", "detail": "Une bibliothèque critique n'est plus maintenue ? Planifiez une migration contrôlée."},
+            {"label": "Signal visibilité", "detail": "Des flux restent non tracés ? Ajoutez des sondes et centralisez les journaux."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Sécurité matérielle", "href": "../pages/hardware-security.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#eff4ff", "#d7e2ff", "#c2d4ff"], "accent": "#3f60ff"},
+        "artDescription": "Illustration générative montrant un réseau de garde-fous élégants."
+    },
+    "supply-chain": {
+        "title": "Chaîne d'approvisionnement IA",
+        "kicker": "Dépendances maîtrisées",
+        "subtitle": "Sécurisez vos dépendances logicielles, données et partenaires.",
+        "description": "Cartographie, évaluations et contrôles de la supply chain IA.",
+        "challenge": "Un fournisseur compromis peut propager une faille à l'ensemble de vos modèles.",
+        "approach": "Identifier, évaluer et surveiller chaque dépendance critique.",
+        "indicator": "Pourcentage de fournisseurs évalués selon vos critères de sécurité IA.",
+        "interactiveIntro": "La sécurité de la supply chain progresse avec des évaluations régulières et des plans de contingence.",
+        "narratives": [
+            {
+                "title": "Cartographier les dépendances",
+                "paragraphs": [
+                    "Recensez fournisseurs, bibliothèques, datasets et APIs. Classez-les par criticité et clarifiez les responsabilités contractuelles." 
+                ]
+            },
+            {
+                "title": "Évaluer les risques",
+                "paragraphs": [
+                    "Mettez en place des questionnaires, audits et tests techniques pour valider la maturité sécurité de vos partenaires." 
+                ]
+            },
+            {
+                "title": "Superviser en continu",
+                "paragraphs": [
+                    "Surveillez les mises à jour, vulnérabilités et incidents déclarés par vos fournisseurs afin d'anticiper les actions correctives." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Maintenir un registre des dépendances IA.",
+            "Évaluer la sécurité des partenaires selon un barème commun.",
+            "Prévoir des clauses contractuelles sur la divulgation des incidents.",
+            "Mettre en place des plans de remédiation partagés."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Identifier les dépendances et leurs propriétaires."},
+            {"label": "Évaluation", "description": "Mesurer la maturité sécurité et les écarts."},
+            {"label": "Contractualisation", "description": "Renforcer les obligations de sécurité et de transparence."},
+            {"label": "Surveillance", "description": "Suivre les changements et incidents dans le temps."}
+        ],
+        "insights": [
+            {"label": "Signal vulnérabilité", "detail": "Un fournisseur annonce une faille critique ? Déployez vos plans de mitigation et vérifiez vos dépendances."},
+            {"label": "Signal retard", "detail": "Les audits fournisseurs prennent du retard ? Priorisez selon la criticité et escaladez."},
+            {"label": "Signal visibilité", "detail": "Vous manquez de transparence sur un partenaire ? Ajoutez des clauses de reporting et des points de contact dédiés."}
+        ],
+        "resources": [
+            {"label": "Sécurité matérielle", "href": "../pages/hardware-security.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Dataset security", "href": "../pages/dataset-security.html"}
+        ],
+        "art": {"palette": ["#f4f7ff", "#dde6ff", "#c8d6ff"], "accent": "#4660ff"},
+        "artDescription": "Illustration générative évoquant un réseau de partenaires maîtrisé."
+    },
+    "threat-modeling": {
+        "title": "Modélisation des menaces",
+        "kicker": "Anticipation stratégique",
+        "subtitle": "Cartographiez les scénarios critiques pour prioriser vos défenses IA.",
+        "description": "Méthodes de threat modeling adaptées aux systèmes d'intelligence artificielle.",
+        "challenge": "Sans modélisation, les efforts de sécurité se dispersent sur de mauvaises priorités.",
+        "approach": "Identifier actifs, adversaires, vecteurs et impacts pour guider les mesures.",
+        "indicator": "Nombre de scénarios de menace analysés et suivis avec plans d'action.",
+        "interactiveIntro": "Le threat modeling devient plus précis lorsque vous combinez experts métier, sécurité et données.",
+        "narratives": [
+            {
+                "title": "Recenser les actifs",
+                "paragraphs": [
+                    "Dressez la liste des modèles, jeux de données et interfaces critiques. Classez-les par valeur métier et sensibilité." 
+                ]
+            },
+            {
+                "title": "Imaginer les adversaires",
+                "paragraphs": [
+                    "Identifiez qui pourrait attaquer, leurs motivations et leurs capacités. Variez les profils : fraudeurs, insiders, concurrents, États." 
+                ]
+            },
+            {
+                "title": "Prioriser les réponses",
+                "paragraphs": [
+                    "Associez chaque scénario à des mesures concrètes : contrôles préventifs, détection, plans de réponse. Mettez-les à jour après chaque incident ou évolution produit." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Cartographier les actifs IA et leurs dépendances.",
+            "Identifier les motivations et capacités adverses.",
+            "Évaluer la vraisemblance et l'impact de chaque scénario.",
+            "Relier les scénarios aux contrôles et plans existants."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Recenser actifs et flux critiques."},
+            {"label": "Analyse", "description": "Identifier menaces, motivations et vecteurs."},
+            {"label": "Priorisation", "description": "Évaluer l'impact et définir les contrôles."},
+            {"label": "Révision", "description": "Mettre à jour selon incidents et évolutions."}
+        ],
+        "insights": [
+            {"label": "Signal nouveau cas", "detail": "Un cas d'usage émerge sans analyse ? Programmez un atelier de threat modeling express."},
+            {"label": "Signal incident", "detail": "Un incident survient en dehors des scénarios ? Ajoutez-le à votre catalogue et ajustez vos contrôles."},
+            {"label": "Signal maturité", "detail": "Les équipes peinent à prioriser ? Utilisez une matrice impact/vraisemblance partagée."}
+        ],
+        "resources": [
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#eef3ff", "#d8e1ff", "#c5d4ff"], "accent": "#3e5dff"},
+        "artDescription": "Illustration générative représentant des cartes de risque raffinées."
+    },
+    "transparency": {
+        "title": "Transparence",
+        "kicker": "Clarté assumée",
+        "subtitle": "Communiquez sur les capacités, limites et risques de vos IA sans compromettre la sécurité.",
+        "description": "Programmes de transparence, rapports et interactions avec les parties prenantes.",
+        "challenge": "Trop de secrets créent de la méfiance, trop d'informations exposent vos défenses.",
+        "approach": "Définissez ce qui peut être partagé, à qui et sous quelle forme.",
+        "indicator": "Nombre de demandes d'information traitées avec un délai conforme.",
+        "interactiveIntro": "La transparence gagne en précision en segmentant audiences et messages.",
+        "narratives": [
+            {
+                "title": "Structurer la communication",
+                "paragraphs": [
+                    "Créez des fiches publiques, des rapports confidentiels et des Q&R internes adaptés à chaque audience : clients, régulateurs, partenaires." 
+                ]
+            },
+            {
+                "title": "Gérer les attentes",
+                "paragraphs": [
+                    "Expliquez clairement les limites, la supervision humaine et les plans de remédiation pour éviter les sur-promesses." 
+                ]
+            },
+            {
+                "title": "Tracer les échanges",
+                "paragraphs": [
+                    "Consignez chaque demande, la réponse fournie et les engagements pris afin de conserver une preuve et d'alimenter vos FAQ." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les audiences et les niveaux de détail autorisés.",
+            "Mettre en place un processus de validation des communications.",
+            "Publier des rapports périodiques et accessibles.",
+            "Capitaliser sur les questions reçues pour enrichir les supports."
+        ],
+        "timeline": [
+            {"label": "Cadrage", "description": "Identifier les parties prenantes et leurs attentes."},
+            {"label": "Production", "description": "Créer les supports adaptés (rapports, fiches, FAQ)."},
+            {"label": "Diffusion", "description": "Communiquer via les canaux validés et suivre les retours."},
+            {"label": "Amélioration", "description": "Mettre à jour les contenus selon incidents et feedbacks."}
+        ],
+        "insights": [
+            {"label": "Signal incompréhension", "detail": "Des parties prenantes confondent vos niveaux de garantie ? Revoyez vos messages et ajoutez des visuels pédagogiques."},
+            {"label": "Signal saturation", "detail": "Vos équipes peinent à répondre aux demandes ? Priorisez et créez des ressources en libre-service."},
+            {"label": "Signal cohérence", "detail": "Les messages divergent selon les interlocuteurs ? Centralisez la gouvernance de la communication."}
+        ],
+        "resources": [
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"},
+            {"label": "Éthique", "href": "../pages/ethics.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#e3eaff", "#cfdcff"], "accent": "#4c63ff"},
+        "artDescription": "Illustration générative symbolisant une diffusion maîtrisée."
+    },
+    "regulation": {
+        "title": "Régulation IA",
+        "kicker": "Veille proactive",
+        "subtitle": "Anticipez les cadres internationaux et transformez-les en actions concrètes.",
+        "description": "Cartographie des réglementations IA, obligations et impacts opérationnels.",
+        "challenge": "Les textes évoluent vite et imposent des exigences lourdes à prouver.",
+        "approach": "Assurez une veille, traduisez les obligations et pilotez la conformité.",
+        "indicator": "Taux d'exigences réglementaires couvertes par des contrôles documentés.",
+        "interactiveIntro": "La maîtrise réglementaire progresse de la veille vers une intégration complète dans vos processus.",
+        "narratives": [
+            {
+                "title": "Organiser la veille",
+                "paragraphs": [
+                    "Constituez un réseau de correspondants juridiques, conformité et sécurité. Partagez une synthèse régulière des évolutions réglementaires." 
+                ]
+            },
+            {
+                "title": "Traduire en exigences",
+                "paragraphs": [
+                    "Convertissez les obligations en contrôles concrets : documentation, tests, comités. Affectez un responsable et un calendrier." 
+                ]
+            },
+            {
+                "title": "Prouver la conformité",
+                "paragraphs": [
+                    "Capitalisez dans un registre les preuves de conformité, préparez les audits et simulez les demandes des autorités." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Mettre en place une veille réglementaire formalisée.",
+            "Cartographier les exigences par cas d'usage IA.",
+            "Associer chaque exigence à un contrôle et un responsable.",
+            "Préparer des dossiers de preuve et scénarios d'audit."
+        ],
+        "timeline": [
+            {"label": "Veille", "description": "Suivre les textes et identifier les nouveautés."},
+            {"label": "Analyse", "description": "Traduire les obligations en exigences internes."},
+            {"label": "Mise en œuvre", "description": "Déployer les contrôles et collecter les preuves."},
+            {"label": "Audit", "description": "Tester la conformité et ajuster selon les retours."}
+        ],
+        "insights": [
+            {"label": "Signal nouveauté", "detail": "Une nouvelle loi est adoptée ? Déclenchez une analyse d'impact et un plan de mise en conformité."},
+            {"label": "Signal audit", "detail": "Une autorité demande un rapport ? Activez votre war room conformité et préparez les preuves."},
+            {"label": "Signal saturation", "detail": "Les équipes peinent à suivre ? Priorisez selon la sévérité des sanctions et négociez des délais."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"}
+        ],
+        "art": {"palette": ["#f2f6ff", "#dfe8ff", "#cbd9ff"], "accent": "#445fff"},
+        "artDescription": "Illustration générative inspirée d'un parlement lumineux."
+    }
+};

--- a/generated/codex-site-20250930/js/sw-register.js
+++ b/generated/codex-site-20250930/js/sw-register.js
@@ -1,0 +1,22 @@
+(() => {
+    if (!('serviceWorker' in navigator)) {
+        console.warn('Service worker non pris en charge.');
+        return;
+    }
+
+    window.addEventListener('load', () => {
+        navigator.serviceWorker
+            .register('service-worker.js')
+            .then((registration) => {
+                console.info('Service worker enregistré.', registration.scope);
+            })
+            .catch((error) => {
+                console.error('Échec de l\'enregistrement du service worker :', error);
+                const announcement = document.createElement('div');
+                announcement.className = 'sw-error';
+                announcement.setAttribute('role', 'status');
+                announcement.textContent = 'Mode hors ligne indisponible. Veuillez vérifier votre navigateur.';
+                document.body.append(announcement);
+            });
+    });
+})();

--- a/generated/codex-site-20250930/manifest.json
+++ b/generated/codex-site-20250930/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "SafeIntelligence Offline",
+  "short_name": "SafeIntelligence",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#f5f7fb",
+  "theme_color": "#3b64ff",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "assets/icons/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/generated/codex-site-20250930/pages/adversarial-learning.html
+++ b/generated/codex-site-20250930/pages/adversarial-learning.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques d'entraînement adversarial, sélection de perturbations et pilotage des performances.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Apprentissage adversarial – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="adversarial-learning">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="adversarial-learning">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Résilience entraînée</p>
+                <h1 class="page__title" data-field="title">Apprentissage adversarial</h1>
+                <p class="page__subtitle" data-field="subtitle">Exposez vos modèles à des attaques simulées pour améliorer leur résistance réelle.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="adversarial-learning" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant des ondes protectrices." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les modèles non exposés aux attaques restent vulnérables à des perturbations minimes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Alternez jeux de données propres et perturbés pour renforcer la stabilité tout en contrôlant la performance.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Écart de performance entre données propres et données adversariales sur vos cas critiques.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque phase élargit le spectre des attaques simulées et la robustesse mesurée.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/alignment.html
+++ b/generated/codex-site-20250930/pages/alignment.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Approches, signaux et garde-fous pour aligner les intelligences artificielles sur vos objectifs.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Alignement des IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="alignment">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="alignment">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Alignement stratégique</p>
+                <h1 class="page__title" data-field="title">Alignement des IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Coordonnez les intentions des modèles avec les valeurs de l'entreprise et la réglementation.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="alignment" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant la convergence de flux alignés." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les objectifs implicites des modèles peuvent diverger des attentes humaines et créer des dommages collatéraux.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Formalisez des chartes d'entraînement, des tests d'alignement comportemental et des revues interfonctionnelles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de non-conformité comportementale détecté par vos batteries de scénarios de tests contextualisés.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque étape d'un programme d'alignement renforce la granularité des garde-fous et la responsabilité partagée.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/auditing.html
+++ b/generated/codex-site-20250930/pages/auditing.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres d'audit IA, checklists et rapports pour démontrer la conformité et la maîtrise des risques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Audit des systèmes IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="auditing">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="auditing">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Contrôle exigeant</p>
+                <h1 class="page__title" data-field="title">Audit des systèmes IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Structurez des audits réguliers couvrant données, modèles, déploiement et opérations.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="auditing" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative rappelant un classeur d'audit raffiné." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans audit, impossible de prouver la conformité ou de détecter une dérive silencieuse.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Planifiez des audits multi-disciplinaires, harmonisez les référentiels et publiez les écarts.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre d'audits critiques réalisés et suivis jusqu'à clôture des actions.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les audits passent d'un diagnostic ponctuel à un programme continu, assisté par des outils.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/contact.html
+++ b/generated/codex-site-20250930/pages/contact.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Coordonnées, ateliers et programme d'accompagnement pour renforcer la sécurité de vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Contact & accompagnement – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="contact">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="contact">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Entrer en relation</p>
+                <h1 class="page__title" data-field="title">Contact & accompagnement</h1>
+                <p class="page__subtitle" data-field="subtitle">Échangeons pour bâtir une feuille de route IA sécurisée adaptée à votre organisation.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="contact" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant une conversation structurée et lumineuse." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les programmes réussis commencent par un diagnostic partagé des enjeux et des attentes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Nous proposons des sessions d'écoute, d'audit express et de définition des priorités.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen entre la prise de contact et la mise en action du premier chantier prioritaire.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque échange renforce votre maturité : de la découverte à la co-construction d'un plan de transformation.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/dataset-security.html
+++ b/generated/codex-site-20250930/pages/dataset-security.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Stratégies de sécurisation, contrôles d'accès et observabilité pour les jeux de données IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Sécurité des jeux de données – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="dataset-security">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="dataset-security">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Intégrité des données</p>
+                <h1 class="page__title" data-field="title">Sécurité des jeux de données</h1>
+                <p class="page__subtitle" data-field="subtitle">Protégez la collecte, la gouvernance et la distribution de vos données d'entraînement.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="dataset-security" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant des couches de données protégées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Des données compromises entraînent des modèles biaisés ou manipulés.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Appliquez segmentation, contrôle d'accès fin et surveillance des contributions externes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'anomalies détectées dans les flux de données d'entraînement.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité des données s'étend des sources à la gouvernance continue.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/differential-privacy.html
+++ b/generated/codex-site-20250930/pages/differential-privacy.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Concepts, paramètres epsilon/delta et stratégies d'implémentation pour la confidentialité différentielle.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Confidentialité différentielle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="differential-privacy">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="differential-privacy">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Protection mathématique</p>
+                <h1 class="page__title" data-field="title">Confidentialité différentielle</h1>
+                <p class="page__subtitle" data-field="subtitle">Appliquez des garanties formelles pour partager des insights sans exposer d'individu.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="differential-privacy" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative symbolisant un voile protecteur mathématique." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans garanties mathématiques, chaque analyse peut divulguer une donnée personnelle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Calibrez le budget de confidentialité et formez les équipes au raisonnement probabiliste.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Budget de confidentialité consommé par rapport au budget alloué.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La confidentialité différentielle exige une montée en compétence progressive et des contrôles outillés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/ethics.html
+++ b/generated/codex-site-20250930/pages/ethics.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres éthiques, comités, évaluations d'impact et liens avec la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Éthique & sécurité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="ethics">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="ethics">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Responsabilité augmentée</p>
+                <h1 class="page__title" data-field="title">Éthique & sécurité</h1>
+                <p class="page__subtitle" data-field="subtitle">Ancrez vos programmes IA dans des valeurs claires et des pratiques responsables.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="ethics" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un équilibre harmonieux." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans garde-fous éthiques, la sécurité peut entrer en conflit avec la confiance du public.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Associez les disciplines éthique, juridique et sécurité pour co-construire les principes directeurs.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de décisions revues par le comité éthique-sécurité et acceptées sans réserve.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">L'éthique se matérialise progressivement par des standards, des évaluations et des arbitrages transparents.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/evaluation.html
+++ b/generated/codex-site-20250930/pages/evaluation.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres d'évaluation, métriques et orchestrations pour suivre la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Évaluations de sécurité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="evaluation">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="evaluation">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Performance contrôlée</p>
+                <h1 class="page__title" data-field="title">Évaluations de sécurité</h1>
+                <p class="page__subtitle" data-field="subtitle">Mesurez la résilience de vos IA avec des protocoles structurés.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="evaluation" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirée d'un tableau de bord élégant." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans évaluation régulière, les mesures de sécurité restent théoriques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des indicateurs alignés aux risques et automatisez la collecte des preuves.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de couverture des scénarios de tests critiques.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les évaluations montent en puissance au fil de la consolidation des données et des outils.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/fail-safes.html
+++ b/generated/codex-site-20250930/pages/fail-safes.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Stratégies de fallback, procédures d'arrêt et communication de crise.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Mécanismes de repli – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="fail-safes">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="fail-safes">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Arrêts gracieux</p>
+                <h1 class="page__title" data-field="title">Mécanismes de repli</h1>
+                <p class="page__subtitle" data-field="subtitle">Planifiez des solutions de secours pour contenir les dérives des IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="fail-safes" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un atterrissage contrôlé." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans plan de repli, une dérive peut se transformer en incident majeur.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Préparez des modes dégradés, des procédures d'arrêt et des scénarios de substitution.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps nécessaire pour activer un fallback et revenir à une situation sûre.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les replis évoluent d'un simple bouton d'arrêt vers des modes dégradés orchestrés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/governance.html
+++ b/generated/codex-site-20250930/pages/governance.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Modèles de gouvernance, comités, politiques et tableaux de bord pour sécuriser vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Gouvernance IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="governance">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="governance">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Capitainerie des risques</p>
+                <h1 class="page__title" data-field="title">Gouvernance IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Établissez un pilotage clair, des rôles définis et des circuits de décision responsables.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="governance" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative structurée rappelant un organigramme épuré." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans chaîne de responsabilité, la sécurité IA reste fragmentée et les incidents se multiplient.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des mandats précis, des politiques approuvées par la direction et des indicateurs de conformité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Pourcentage de décisions critiques disposant d'un propriétaire clairement identifié.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La gouvernance s'étoffe d'abord par la définition des rôles, puis par des rituels et enfin par l'automatisation des contrôles.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/hardware-security.html
+++ b/generated/codex-site-20250930/pages/hardware-security.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Mesures physiques, firmware et monitoring pour une infrastructure IA sécurisée.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Sécurité matérielle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="hardware-security">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="hardware-security">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Infrastructure blindée</p>
+                <h1 class="page__title" data-field="title">Sécurité matérielle</h1>
+                <p class="page__subtitle" data-field="subtitle">Protégez les accélérateurs IA, racks et environnements physiques.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="hardware-security" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant une forteresse matérielle." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les attaques matérielles peuvent contourner toutes les protections logicielles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Segmenter, surveiller et attester vos équipements pour garantir leur intégrité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'équipements avec attestation de démarrage vérifiée.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité matérielle progresse du verrouillage physique vers des chaînes d'attestation complètes.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/human-in-the-loop.html
+++ b/generated/codex-site-20250930/pages/human-in-the-loop.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Processus, outils et ergonomie pour intégrer l'humain dans les boucles de décision.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Humain dans la boucle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="human-in-the-loop">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="human-in-the-loop">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Synergie supervisée</p>
+                <h1 class="page__title" data-field="title">Humain dans la boucle</h1>
+                <p class="page__subtitle" data-field="subtitle">Organisez des interactions fluides entre opérateurs et modèles IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="human-in-the-loop" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative illustrant la collaboration homme-machine." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans implication humaine, les dérives passent inaperçues et la confiance s'érode.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez les points de validation humaine, équipez les opérateurs et mesurez leur charge.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps médian de validation humaine et taux d'escalade.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">L'humain devient partenaire du modèle à mesure que les outils facilitent la collaboration.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/incident-response.html
+++ b/generated/codex-site-20250930/pages/incident-response.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Plans de réponse, communication de crise et post-mortems adaptés aux incidents IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Réponse aux incidents IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="incident-response">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="incident-response">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Précision tactique</p>
+                <h1 class="page__title" data-field="title">Réponse aux incidents IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Préparez vos équipes à gérer et résoudre les incidents IA avec assurance.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="incident-response" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative illustrant une intervention maîtrisée." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les incidents IA demandent des réflexes spécifiques souvent absents des plans classiques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Adaptez vos plans de réponse et entraînez vos équipes à ces nouveaux scénarios.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen de détection et de résolution d'un incident IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La réponse gagne en efficacité en combinant procédures, simulation et retour d'expérience.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/interpretability.html
+++ b/generated/codex-site-20250930/pages/interpretability.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques d'explicabilité, cartographies de features et protocoles de restitution pour vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Interprétabilité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="interpretability">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="interpretability">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Transparence cognitive</p>
+                <h1 class="page__title" data-field="title">Interprétabilité</h1>
+                <p class="page__subtitle" data-field="subtitle">Exposez les décisions algorithmiques pour faciliter l'audit et la confiance des parties prenantes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="interpretability" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative suggérant la décomposition d'une décision IA." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans transparence, impossible de comprendre ou de contester un résultat critique produit par le modèle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Combinez interprétabilité intrinsèque, outils post-hoc et documentations de données pour couvrir tous les angles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen nécessaire pour expliquer une décision critique à un auditeur externe.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque phase améliore la granularité des explications et la fluidité de vos restitutions.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/monitoring.html
+++ b/generated/codex-site-20250930/pages/monitoring.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Capteurs, métriques et opérations pour une surveillance IA 24/7.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Surveillance continue – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="monitoring">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="monitoring">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Sentinelle proactive</p>
+                <h1 class="page__title" data-field="title">Surveillance continue</h1>
+                <p class="page__subtitle" data-field="subtitle">Détectez les dérives et incidents IA en temps réel.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="monitoring" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un radar élégant." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans surveillance, une dérive peut durer des jours avant d'être détectée.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Déployez des capteurs adaptés, des seuils intelligents et des équipes en alerte.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps médian de détection d'une anomalie IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La surveillance gagne en précision avec des signaux multiples et des workflows intégrés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/oversight.html
+++ b/generated/codex-site-20250930/pages/oversight.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Processus de supervision, reporting et arbitrages pour la direction.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Supervision humaine – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="oversight">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="oversight">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Pilotage éclairé</p>
+                <h1 class="page__title" data-field="title">Supervision humaine</h1>
+                <p class="page__subtitle" data-field="subtitle">Organisez la supervision stratégique de vos IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="oversight" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirant une tour de contrôle lumineuse." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans supervision, les décisions critiques échappent au contrôle stratégique.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des comités, des rapports et des processus de validation.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de projets IA revus par les organes de supervision.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La supervision se renforce avec des rituels et des données consolidées.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/policy.html
+++ b/generated/codex-site-20250930/pages/policy.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Rédaction, diffusion et gouvernance des politiques internes liées à la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Politiques internes IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="policy">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="policy">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Cadre commun</p>
+                <h1 class="page__title" data-field="title">Politiques internes IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Formalisez les règles, standards et lignes directrices pour vos IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="policy" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative rappelant un livret premium." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans politiques, chaque équipe improvise et multiplie les risques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Élaborez des politiques claires, accessibles et applicables par tous.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'équipes ayant attesté lire et appliquer les politiques IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les politiques gagnent en efficacité lorsqu'elles sont co-construites, testées et mises à jour.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/red-teaming.html
+++ b/generated/codex-site-20250930/pages/red-teaming.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Méthodologies de red teaming, scripts adversariaux et reporting pour IA génératives et prédictives.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Red Teaming IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="red-teaming">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="red-teaming">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Offensive contrôlée</p>
+                <h1 class="page__title" data-field="title">Red Teaming IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Testez vos systèmes avec des attaques orchestrées pour découvrir les failles avant les adversaires.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="red-teaming" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant des trajectoires offensives contrôlées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans simulations réalistes, les vulnérabilités restent invisibles jusqu'à l'exploitation réelle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Bâtissez une équipe multidisciplinaire, définissez des règles d'engagement et cadrez la restitution.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de vulnérabilités découvertes en interne avant qu'elles ne soient signalées par l'extérieur.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Le red teaming gagne en précision en passant de scénarios exploratoires à des campagnes orchestrées.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/regulation.html
+++ b/generated/codex-site-20250930/pages/regulation.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cartographie des réglementations IA, obligations et impacts opérationnels.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Régulation IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="regulation">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="regulation">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Veille proactive</p>
+                <h1 class="page__title" data-field="title">Régulation IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Anticipez les cadres internationaux et transformez-les en actions concrètes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="regulation" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirée d'un parlement lumineux." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les textes évoluent vite et imposent des exigences lourdes à prouver.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Assurez une veille, traduisez les obligations et pilotez la conformité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'exigences réglementaires couvertes par des contrôles documentés.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La maîtrise réglementaire progresse de la veille vers une intégration complète dans vos processus.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/robustness.html
+++ b/generated/codex-site-20250930/pages/robustness.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques de durcissement, stress tests et suivi de la robustesse.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Robustesse des modèles – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="robustness">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="robustness">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Résilience opérationnelle</p>
+                <h1 class="page__title" data-field="title">Robustesse des modèles</h1>
+                <p class="page__subtitle" data-field="subtitle">Renforcez la résistance de vos modèles aux perturbations et scénarios extrêmes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="robustness" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative montrant des couches protectrices dynamiques." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Une IA fragile amplifie les risques dès qu'un signal inattendu survient.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Combiner tests adversariaux, régularisation et architecture résiliente.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Écart de performance entre conditions nominales et dégradées.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La robustesse s'améliore en multipliant les tests et en renforçant l'observabilité.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/scheming.html
+++ b/generated/codex-site-20250930/pages/scheming.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Scénarios de scheming, méthodes de détection et garde-fous organisationnels.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Comportements stratégiques – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="scheming">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="scheming">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Prévoir l'imprévu</p>
+                <h1 class="page__title" data-field="title">Comportements stratégiques</h1>
+                <p class="page__subtitle" data-field="subtitle">Détectez et contenir les tactiques opportunistes que peuvent adopter des IA avancées.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="scheming" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative suggérant des trajectoires déviantes maîtrisées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Des modèles sophistiqués peuvent apprendre à contourner les contrôles et optimiser contre vos intérêts.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Concevez des tests scénarisés, multipliez les signaux et imposez des limites claires aux modèles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de comportements opportunistes détectés et neutralisés avant impact.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Anticiper le scheming demande de diversifier les audits et de renforcer la supervision humaine.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/secure-architecture.html
+++ b/generated/codex-site-20250930/pages/secure-architecture.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Patrons d'architecture, segmentation et contrôles de sécurité pour les chaînes IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Architecture sécurisée – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="secure-architecture">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="secure-architecture">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Fondations maîtrisées</p>
+                <h1 class="page__title" data-field="title">Architecture sécurisée</h1>
+                <p class="page__subtitle" data-field="subtitle">Concevez des pipelines IA fiables de bout en bout.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="secure-architecture" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative montrant un réseau de garde-fous élégants." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans architecture robuste, chaque composant devient un point d'entrée.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Segmenter les environnements, sécuriser les interfaces et tracer chaque interaction.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de contrôles de sécurité automatisés dans la chaîne de développement.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Une architecture sécurisée évolue avec des couches de contrôle supplémentaires et des audits réguliers.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/supply-chain.html
+++ b/generated/codex-site-20250930/pages/supply-chain.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cartographie, évaluations et contrôles de la supply chain IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Chaîne d'approvisionnement IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="supply-chain">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="supply-chain">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Dépendances maîtrisées</p>
+                <h1 class="page__title" data-field="title">Chaîne d'approvisionnement IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Sécurisez vos dépendances logicielles, données et partenaires.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="supply-chain" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant un réseau de partenaires maîtrisé." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Un fournisseur compromis peut propager une faille à l'ensemble de vos modèles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Identifier, évaluer et surveiller chaque dépendance critique.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Pourcentage de fournisseurs évalués selon vos critères de sécurité IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité de la supply chain progresse avec des évaluations régulières et des plans de contingence.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/threat-modeling.html
+++ b/generated/codex-site-20250930/pages/threat-modeling.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Méthodes de threat modeling adaptées aux systèmes d'intelligence artificielle.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Modélisation des menaces – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="threat-modeling">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="threat-modeling">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Anticipation stratégique</p>
+                <h1 class="page__title" data-field="title">Modélisation des menaces</h1>
+                <p class="page__subtitle" data-field="subtitle">Cartographiez les scénarios critiques pour prioriser vos défenses IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="threat-modeling" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant des cartes de risque raffinées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans modélisation, les efforts de sécurité se dispersent sur de mauvaises priorités.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Identifier actifs, adversaires, vecteurs et impacts pour guider les mesures.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de scénarios de menace analysés et suivis avec plans d'action.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Le threat modeling devient plus précis lorsque vous combinez experts métier, sécurité et données.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/pages/transparency.html
+++ b/generated/codex-site-20250930/pages/transparency.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Programmes de transparence, rapports et interactions avec les parties prenantes.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Transparence – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="transparency">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="transparency">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Clarté assumée</p>
+                <h1 class="page__title" data-field="title">Transparence</h1>
+                <p class="page__subtitle" data-field="subtitle">Communiquez sur les capacités, limites et risques de vos IA sans compromettre la sécurité.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="transparency" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative symbolisant une diffusion maîtrisée." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Trop de secrets créent de la méfiance, trop d'informations exposent vos défenses.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez ce qui peut être partagé, à qui et sous quelle forme.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de demandes d'information traitées avec un délai conforme.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La transparence gagne en précision en segmentant audiences et messages.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/generated/codex-site-20250930/service-worker.js
+++ b/generated/codex-site-20250930/service-worker.js
@@ -1,0 +1,72 @@
+const CACHE_NAME = 'safeintelligence-v2';
+const ASSETS = [
+    './',
+    './assets/icons/icon.svg',
+    './css/styles.css',
+    './index.html',
+    './js/page-data.js',
+    './js/app.js',
+    './js/sw-register.js',
+    './manifest.json',
+    './pages/adversarial-learning.html',
+    './pages/alignment.html',
+    './pages/auditing.html',
+    './pages/contact.html',
+    './pages/dataset-security.html',
+    './pages/differential-privacy.html',
+    './pages/ethics.html',
+    './pages/evaluation.html',
+    './pages/fail-safes.html',
+    './pages/governance.html',
+    './pages/hardware-security.html',
+    './pages/human-in-the-loop.html',
+    './pages/incident-response.html',
+    './pages/interpretability.html',
+    './pages/monitoring.html',
+    './pages/oversight.html',
+    './pages/policy.html',
+    './pages/red-teaming.html',
+    './pages/regulation.html',
+    './pages/robustness.html',
+    './pages/scheming.html',
+    './pages/secure-architecture.html',
+    './pages/supply-chain.html',
+    './pages/threat-modeling.html',
+    './pages/transparency.html'
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys().then((keys) => Promise.all(
+            keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+        ))
+    );
+    self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+    if (request.method !== 'GET') {
+        return;
+    }
+
+    event.respondWith(
+        caches.match(request).then((cachedResponse) => {
+            if (cachedResponse) {
+                return cachedResponse;
+            }
+            return fetch(request).then((networkResponse) => {
+                const cloned = networkResponse.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+                return networkResponse;
+            }).catch(() => caches.match('./index.html'));
+        })
+    );
+});

--- a/generated/codex-site-20250930/test/check_site.js
+++ b/generated/codex-site-20250930/test/check_site.js
@@ -1,0 +1,55 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const port = 8123;
+
+const server = http.createServer((req, res) => {
+  const requestPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(rootDir, requestPath);
+
+  fs.readFile(filePath, (error, data) => {
+    if (error) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = ext === '.html' ? 'text/html; charset=utf-8' :
+      ext === '.css' ? 'text/css; charset=utf-8' :
+      ext === '.js' ? 'application/javascript; charset=utf-8' :
+      'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  http.get(`http://127.0.0.1:${port}/index.html`, (response) => {
+    const { statusCode } = response;
+    if (statusCode !== 200) {
+      console.error(`Échec: statut ${statusCode}`);
+      server.close(() => process.exit(1));
+      return;
+    }
+    let body = '';
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+    response.on('end', () => {
+      const hasMeta = body.includes('<meta name="offline-ready" content="true"');
+      if (!hasMeta) {
+        console.error('La balise <meta name="offline-ready" content="true"> est absente.');
+        server.close(() => process.exit(1));
+        return;
+      }
+      console.log('Test réussi: index.html répond et contient la balise meta offline-ready.');
+      server.close(() => process.exit(0));
+    });
+  }).on('error', (error) => {
+    console.error('Erreur de requête HTTP:', error);
+    server.close(() => process.exit(1));
+  });
+});

--- a/my-offline-site/README.md
+++ b/my-offline-site/README.md
@@ -1,0 +1,66 @@
+# My Offline Site
+
+Ce dépôt contient un site web entièrement hors ligne explorant les enjeux de la sécurité des intelligences artificielles.
+
+## Fonctionnalités principales
+- **Progressive Web App** avec manifest et service worker en cache-first.
+- **25 pages de contenu enrichi** avec textes thématiques, timelines interactives, checklists et ressources croisées.
+- **Animations CSS et JavaScript** (défilement, particules canvas, curseur de scénarios, onglets d'insights) pour une expérience fluide.
+- **Illustrations génératives** : chaque page et la galerie d'accueil chargent une image créée localement par un canvas procédural.
+- **Accessibilité et responsive design** inspiré d'une charte graphique sobre et élégante.
+- **Dépendances 100 % locales** : aucune ressource distante, aucune police externe.
+
+## Structure
+```
+my-offline-site/
+├─ index.html
+├─ README.md
+├─ manifest.json
+├─ service-worker.js
+├─ css/
+│  └─ styles.css
+├─ js/
+│  ├─ app.js
+│  ├─ page-data.js
+│  └─ sw-register.js
+├─ assets/
+│  ├─ images/
+│  │  └─ hero.jpg.placeholder
+│  └─ icons/
+│     ├─ icon-192.png.placeholder
+│     └─ icon.svg
+└─ test/
+   └─ check_site.js
+```
+
+## Personnaliser les contenus
+
+Les textes, checklists, timelines et insights de chaque page sont centralisés dans `js/page-data.js`. Modifiez ce fichier pour adapter les contenus ou les palettes des illustrations génératives. Les pages consomment ces données dynamiquement lors du chargement.
+
+## Remplacer les placeholders binaires
+
+- `assets/images/hero.jpg.placeholder` → remplacez par votre visuel `hero.jpg` (même nom sans l'extension `.placeholder`).
+- `assets/icons/icon-192.png.placeholder` → remplacez par une icône carrée 192×192 `icon-192.png`.
+
+Supprimez les fichiers `.placeholder` après les avoir remplacés et, si nécessaire, ajustez les références dans `manifest.json` et `index.html`.
+
+## Lancer un serveur local
+
+Le service worker requiert un contexte sécurisé. Utilisez un serveur de développement simple :
+
+```bash
+cd my-offline-site
+python -m http.server 8000
+```
+
+Ensuite, ouvrez [http://localhost:8000](http://localhost:8000) dans votre navigateur. Après le premier chargement, le service worker mettra les ressources en cache pour une navigation hors connexion.
+
+## Tests
+Le script `test/check_site.js` vérifie que la page d'accueil répond correctement et contient la balise `meta` indiquant la compatibilité hors ligne. Exécutez :
+
+```bash
+node test/check_site.js
+```
+
+## Licence
+Projet mis à disposition sans licence spécifique. Utilisation libre.

--- a/my-offline-site/assets/icons/icon-192.png.placeholder
+++ b/my-offline-site/assets/icons/icon-192.png.placeholder
@@ -1,0 +1,1 @@
+remplacer par icon-192.png

--- a/my-offline-site/assets/icons/icon.svg
+++ b/my-offline-site/assets/icons/icon.svg
@@ -1,0 +1,10 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 192 192">
+  <defs>
+    <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0f172a" />
+      <stop offset="100%" stop-color="#334155" />
+    </linearGradient>
+  </defs>
+  <rect width="192" height="192" rx="40" fill="url(#grad)" />
+  <path d="M58 96c0-21 17-38 38-38s38 17 38 38-17 38-38 38-38-17-38-38zm38-52c-28.7 0-52 23.3-52 52s23.3 52 52 52 52-23.3 52-52-23.3-52-52-52zm0 32c11 0 20 9 20 20s-9 20-20 20-20-9-20-20 9-20 20-20z" fill="#f8fafc" fill-rule="evenodd" />
+</svg>

--- a/my-offline-site/assets/images/hero.jpg.placeholder
+++ b/my-offline-site/assets/images/hero.jpg.placeholder
@@ -1,0 +1,1 @@
+remplacer par hero.jpg

--- a/my-offline-site/css/styles.css
+++ b/my-offline-site/css/styles.css
@@ -1,0 +1,931 @@
+:root {
+    color-scheme: light;
+    --font-sans: "SF Pro Text", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    --font-display: "SF Pro Display", "Segoe UI", -apple-system, BlinkMacSystemFont, "Helvetica Neue", Arial, sans-serif;
+    --color-background: #f5f7fb;
+    --color-surface: rgba(255, 255, 255, 0.78);
+    --color-surface-solid: #ffffff;
+    --color-border: rgba(27, 43, 99, 0.12);
+    --color-text: #0c1633;
+    --color-muted: #5b6b92;
+    --color-accent: #3b64ff;
+    --color-accent-soft: rgba(59, 100, 255, 0.12);
+    --color-highlight: #9fb6ff;
+    --shadow-soft: 0 18px 44px rgba(15, 33, 66, 0.12);
+    --shadow-sharp: 0 12px 24px rgba(15, 33, 66, 0.18);
+    --radius-large: 32px;
+    --radius-medium: 20px;
+    --radius-small: 12px;
+    --max-width: 1120px;
+    --transition: 220ms ease;
+    --blur: 18px;
+}
+
+*,
+*::before,
+*::after {
+    box-sizing: border-box;
+}
+
+html {
+    font-size: 100%;
+    scroll-behavior: smooth;
+}
+
+body {
+    margin: 0;
+    font-family: var(--font-sans);
+    color: var(--color-text);
+    background: radial-gradient(circle at 20% 20%, rgba(119, 154, 255, 0.18), transparent 45%),
+        radial-gradient(circle at 80% 0%, rgba(162, 185, 255, 0.12), transparent 40%),
+        linear-gradient(180deg, #f9fbff 0%, #eef3ff 100%);
+    min-height: 100vh;
+}
+
+body::before {
+    content: "";
+    position: fixed;
+    inset: 0;
+    background: linear-gradient(120deg, rgba(82, 118, 255, 0.12), rgba(255, 255, 255, 0));
+    opacity: 0.7;
+    pointer-events: none;
+    z-index: -2;
+}
+
+img,
+svg,
+canvas {
+    max-width: 100%;
+    display: block;
+}
+
+.skip-link {
+    position: absolute;
+    top: -40px;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--color-accent);
+    color: #fff;
+    padding: 0.75rem 1.25rem;
+    border-radius: var(--radius-small);
+    font-weight: 600;
+    transition: top var(--transition);
+    z-index: 1000;
+}
+
+.skip-link:focus {
+    top: 12px;
+}
+
+.header {
+    position: sticky;
+    top: 0;
+    z-index: 999;
+    backdrop-filter: blur(var(--blur));
+    background: rgba(245, 247, 251, 0.85);
+    border-bottom: 1px solid transparent;
+    transition: background var(--transition), border-color var(--transition), box-shadow var(--transition);
+}
+
+.header.is-scrolled {
+    background: rgba(239, 244, 255, 0.92);
+    border-color: var(--color-border);
+    box-shadow: 0 10px 30px rgba(19, 36, 78, 0.08);
+}
+
+.header__inner {
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 1rem 1.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+}
+
+.logo {
+    font-family: var(--font-display);
+    font-weight: 700;
+    font-size: 1.25rem;
+    letter-spacing: 0.02em;
+    text-decoration: none;
+    color: var(--color-text);
+}
+
+.nav {
+    position: relative;
+}
+
+.nav__toggle {
+    display: none;
+    background: rgba(255, 255, 255, 0.75);
+    border: 1px solid rgba(59, 100, 255, 0.2);
+    border-radius: 999px;
+    padding: 0.5rem 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    color: var(--color-text);
+    transition: background var(--transition), transform var(--transition);
+}
+
+.nav__toggle:focus-visible,
+.nav__toggle:hover {
+    background: rgba(59, 100, 255, 0.12);
+    transform: translateY(-1px);
+}
+
+.nav__list {
+    display: flex;
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    gap: 1rem;
+}
+
+.nav__list a {
+    text-decoration: none;
+    color: var(--color-muted);
+    font-weight: 600;
+    padding: 0.6rem 1rem;
+    border-radius: 999px;
+    transition: color var(--transition), background var(--transition), box-shadow var(--transition);
+}
+
+.nav__list a:focus-visible,
+.nav__list a:hover {
+    color: var(--color-text);
+    background: rgba(255, 255, 255, 0.8);
+    box-shadow: inset 0 0 0 1px rgba(59, 100, 255, 0.12);
+}
+
+.hero {
+    position: relative;
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+    align-items: center;
+    min-height: clamp(520px, 88vh, 760px);
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 4.5rem 1.5rem 4rem;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 2.5rem;
+    z-index: -1;
+    border-radius: var(--radius-large);
+    background: rgba(255, 255, 255, 0.48);
+    filter: blur(0px);
+    box-shadow: 0 24px 68px rgba(15, 33, 66, 0.16);
+    opacity: 0.65;
+}
+
+.hero__content {
+    display: grid;
+    gap: 1.25rem;
+    position: relative;
+    z-index: 2;
+}
+
+.hero__kicker {
+    font-weight: 700;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--color-accent);
+    font-size: 0.85rem;
+}
+
+.hero__title {
+    font-family: var(--font-display);
+    font-size: clamp(2.25rem, 5vw, 3.6rem);
+    margin: 0;
+    line-height: 1.05;
+}
+
+.hero__subtitle {
+    margin: 0;
+    font-size: 1.1rem;
+    color: var(--color-muted);
+    max-width: 34ch;
+}
+
+.hero__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.hero__visual {
+    position: relative;
+    width: 100%;
+    aspect-ratio: 4 / 3;
+    border-radius: var(--radius-large);
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(59, 100, 255, 0.75), rgba(168, 187, 255, 0.4));
+    box-shadow: var(--shadow-soft);
+    display: grid;
+    place-items: center;
+}
+
+.hero__visual::before,
+.hero__visual::after {
+    content: "";
+    position: absolute;
+    border-radius: 50%;
+    filter: blur(30px);
+    opacity: 0.85;
+}
+
+.hero__visual::before {
+    width: 280px;
+    height: 280px;
+    background: radial-gradient(circle, rgba(255, 255, 255, 0.95), rgba(59, 100, 255, 0));
+    animation: floatOrb 12s ease-in-out infinite;
+}
+
+.hero__visual::after {
+    width: 420px;
+    height: 420px;
+    background: radial-gradient(circle, rgba(150, 173, 255, 0.5), transparent);
+    animation: floatOrbAlt 16s ease-in-out infinite;
+}
+
+#particle-canvas {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+    z-index: 1;
+    mix-blend-mode: screen;
+}
+
+.btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+    padding: 0.8rem 1.5rem;
+    border-radius: 999px;
+    border: none;
+    background: var(--color-accent);
+    color: #fff;
+    font-weight: 600;
+    text-decoration: none;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background var(--transition);
+    box-shadow: 0 12px 30px rgba(59, 100, 255, 0.35);
+}
+
+.btn:focus-visible,
+.btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 18px 40px rgba(59, 100, 255, 0.45);
+}
+
+.btn--ghost {
+    background: rgba(255, 255, 255, 0.65);
+    color: var(--color-text);
+    box-shadow: inset 0 0 0 1px rgba(59, 100, 255, 0.25);
+}
+
+.btn--ghost:focus-visible,
+.btn--ghost:hover {
+    background: rgba(255, 255, 255, 0.9);
+}
+
+main {
+    display: grid;
+    gap: 4rem;
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 0 1.5rem 5rem;
+}
+
+.section {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3.5rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.section::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(140deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.section:hover::after {
+    opacity: 1;
+}
+
+.section--grid {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.section__header {
+    max-width: 720px;
+}
+
+.section__header h2 {
+    margin: 0;
+    font-family: var(--font-display);
+    font-size: clamp(1.8rem, 3vw, 2.4rem);
+}
+
+.section__header p {
+    color: var(--color-muted);
+    margin: 1rem 0 0;
+    font-size: 1.05rem;
+}
+
+.topics-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1.2rem;
+}
+
+.topic-card {
+    display: grid;
+    gap: 0.6rem;
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.25rem 1.4rem;
+    border-radius: var(--radius-medium);
+    text-decoration: none;
+    color: inherit;
+    border: 1px solid transparent;
+    box-shadow: 0 12px 24px rgba(15, 33, 66, 0.08);
+    transition: transform var(--transition), box-shadow var(--transition), border-color var(--transition), background var(--transition);
+}
+
+.topic-card:hover,
+.topic-card:focus-visible {
+    transform: translateY(-4px);
+    box-shadow: 0 20px 36px rgba(15, 33, 66, 0.12);
+    border-color: rgba(59, 100, 255, 0.18);
+    background: rgba(248, 250, 255, 0.95);
+}
+
+.topic-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+    font-family: var(--font-display);
+}
+
+.topic-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.gallery {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+}
+
+.gallery__item {
+    position: relative;
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+    background: rgba(255, 255, 255, 0.65);
+    padding: 1.25rem;
+    display: grid;
+    gap: 0.75rem;
+    box-shadow: 0 14px 36px rgba(19, 36, 78, 0.1);
+}
+
+.gallery__item img {
+    border-radius: var(--radius-small);
+    filter: saturate(1.1);
+    transition: transform 700ms cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.gallery__item:hover img {
+    transform: scale(1.04);
+}
+
+.gallery__legend {
+    font-size: 0.95rem;
+    color: var(--color-muted);
+}
+
+.scenario {
+    display: grid;
+    gap: 1.25rem;
+    background: rgba(255, 255, 255, 0.86);
+    padding: 2rem;
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.14);
+    box-shadow: 0 16px 40px rgba(15, 33, 66, 0.1);
+}
+
+.scenario__label {
+    font-weight: 600;
+    color: var(--color-muted);
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+
+.scenario__output {
+    display: grid;
+    gap: 0.6rem;
+}
+
+input[type="range"] {
+    width: 100%;
+    accent-color: var(--color-accent);
+}
+
+.badge-list {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    padding: 0;
+    margin: 0;
+    list-style: none;
+}
+
+.badge-list li {
+    padding: 0.5rem 1rem;
+    border-radius: 999px;
+    background: var(--color-accent-soft);
+    color: var(--color-accent);
+    font-weight: 600;
+}
+
+.footer {
+    padding: 3rem 1.5rem;
+    text-align: center;
+    color: var(--color-muted);
+}
+
+.footer p {
+    margin: 0.4rem 0;
+}
+
+.reveal {
+    opacity: 0;
+    transform: translateY(32px);
+    transition: opacity 600ms ease, transform 600ms ease;
+}
+
+.reveal.is-visible {
+    opacity: 1;
+    transform: translateY(0);
+}
+
+@keyframes floatOrb {
+    0%,
+    100% {
+        transform: translate(0, 0) scale(1);
+    }
+    50% {
+        transform: translate(-12px, 18px) scale(1.08);
+    }
+}
+
+@keyframes floatOrbAlt {
+    0%,
+    100% {
+        transform: translate(0, 0) scale(0.98);
+    }
+    40% {
+        transform: translate(16px, -12px) scale(1.06);
+    }
+}
+
+.page {
+    background: none;
+}
+
+.page__main {
+    display: grid;
+    gap: 3rem;
+    margin: 0 auto;
+    max-width: var(--max-width);
+    padding: 4rem 1.5rem 5rem;
+}
+
+.page__hero {
+    display: grid;
+    gap: 2rem;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    align-items: center;
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3.5rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.page__hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: linear-gradient(150deg, rgba(255, 255, 255, 0.8), rgba(225, 234, 255, 0.1));
+    z-index: -1;
+}
+
+.page__hero-text {
+    display: grid;
+    gap: 1rem;
+}
+
+.page__kicker {
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.22em;
+    color: var(--color-accent);
+    font-size: 0.85rem;
+}
+
+.page__title {
+    font-family: var(--font-display);
+    font-size: clamp(2rem, 4vw, 2.8rem);
+    margin: 0;
+}
+
+.page__subtitle {
+    margin: 0;
+    color: var(--color-muted);
+    font-size: 1.05rem;
+}
+
+.page__cta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.page__hero-figure {
+    position: relative;
+    padding: 1rem;
+}
+
+.page__hero-figure::before {
+    content: "";
+    position: absolute;
+    inset: 10%;
+    border-radius: var(--radius-large);
+    background: linear-gradient(135deg, rgba(59, 100, 255, 0.18), rgba(255, 255, 255, 0));
+    filter: blur(0px);
+    z-index: -1;
+}
+
+.page__illustration {
+    width: 100%;
+    border-radius: var(--radius-medium);
+    box-shadow: var(--shadow-sharp);
+    background: #fff;
+}
+
+.page__summary {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.summary-card {
+    background: rgba(255, 255, 255, 0.85);
+    padding: 1.75rem;
+    border-radius: var(--radius-medium);
+    box-shadow: 0 16px 36px rgba(15, 33, 66, 0.1);
+    border: 1px solid rgba(59, 100, 255, 0.12);
+    display: grid;
+    gap: 0.6rem;
+}
+
+.summary-card h2,
+.summary-card h3 {
+    margin: 0;
+    font-size: 1.15rem;
+}
+
+.summary-card p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.page__narrative,
+.page__interactive,
+.page__checklist,
+.page__resources {
+    background: var(--color-surface);
+    border-radius: var(--radius-large);
+    padding: clamp(2rem, 5vw, 3rem);
+    box-shadow: var(--shadow-soft);
+    position: relative;
+    overflow: hidden;
+}
+
+.page__narrative::after,
+.page__interactive::after,
+.page__checklist::after,
+.page__resources::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0.9), rgba(255, 255, 255, 0));
+    opacity: 0;
+    transition: opacity var(--transition);
+}
+
+.page__narrative:hover::after,
+.page__interactive:hover::after,
+.page__checklist:hover::after,
+.page__resources:hover::after {
+    opacity: 1;
+}
+
+.narrative-grid {
+    display: grid;
+    gap: 1.5rem;
+    grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.narrative-block {
+    background: rgba(255, 255, 255, 0.9);
+    padding: 1.5rem;
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.1);
+    box-shadow: 0 14px 30px rgba(19, 36, 78, 0.1);
+    display: grid;
+    gap: 0.75rem;
+    position: relative;
+}
+
+.narrative-block::before {
+    content: "";
+    position: absolute;
+    top: 1.2rem;
+    left: 1.2rem;
+    width: 40px;
+    height: 3px;
+    background: linear-gradient(90deg, var(--color-accent), transparent);
+    border-radius: 999px;
+}
+
+.narrative-block h3 {
+    margin: 0;
+    padding-top: 0.5rem;
+    font-size: 1.2rem;
+    font-family: var(--font-display);
+}
+
+.narrative-block p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.timeline {
+    display: grid;
+    gap: 1rem;
+    padding: 1.5rem;
+    border-radius: var(--radius-medium);
+    background: rgba(255, 255, 255, 0.9);
+    border: 1px solid rgba(59, 100, 255, 0.12);
+    box-shadow: 0 16px 32px rgba(15, 33, 66, 0.1);
+}
+
+.timeline__display {
+    display: grid;
+    gap: 0.5rem;
+}
+
+.timeline__display h3 {
+    margin: 0;
+}
+
+.timeline__display p {
+    margin: 0;
+    color: var(--color-muted);
+}
+
+.insight {
+    display: grid;
+    gap: 1rem;
+}
+
+.insight__tabs {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+}
+
+.insight__tabs button {
+    border: 1px solid rgba(59, 100, 255, 0.2);
+    border-radius: 999px;
+    padding: 0.6rem 1rem;
+    background: rgba(255, 255, 255, 0.75);
+    cursor: pointer;
+    font-weight: 600;
+    color: var(--color-muted);
+    transition: background var(--transition), color var(--transition), box-shadow var(--transition);
+}
+
+.insight__tabs button[aria-selected="true"],
+.insight__tabs button:hover,
+.insight__tabs button:focus-visible {
+    background: var(--color-accent);
+    color: #fff;
+    box-shadow: 0 12px 24px rgba(59, 100, 255, 0.3);
+}
+
+.insight__panel {
+    min-height: 3.5rem;
+    color: var(--color-text);
+    font-size: 1.05rem;
+}
+
+.checklist {
+    list-style: none;
+    padding: 0;
+    margin: 1.5rem 0 0;
+    display: grid;
+    gap: 0.75rem;
+}
+
+.checklist li {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 0.75rem;
+    align-items: start;
+    padding: 0.9rem 1.2rem;
+    background: rgba(255, 255, 255, 0.9);
+    border-radius: var(--radius-medium);
+    border: 1px solid rgba(59, 100, 255, 0.14);
+    box-shadow: 0 12px 26px rgba(19, 36, 78, 0.08);
+}
+
+.checklist li::before {
+    content: "";
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    margin-top: 0.25rem;
+    background: radial-gradient(circle at 30% 30%, #fff, var(--color-accent));
+    box-shadow: 0 0 0 3px rgba(59, 100, 255, 0.15);
+}
+
+.resource-list {
+    list-style: none;
+    display: grid;
+    gap: 0.8rem;
+    margin: 1.5rem 0 0;
+    padding: 0;
+}
+
+.resource-list a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.65rem 1rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.8);
+    text-decoration: none;
+    color: var(--color-accent);
+    font-weight: 600;
+    transition: transform var(--transition), box-shadow var(--transition);
+}
+
+.resource-list a:hover,
+.resource-list a:focus-visible {
+    transform: translateY(-2px);
+    box-shadow: 0 14px 30px rgba(15, 33, 66, 0.15);
+}
+
+.badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.85rem;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(59, 100, 255, 0.12);
+    color: var(--color-accent);
+}
+
+[data-sparkle] {
+    position: relative;
+    overflow: hidden;
+}
+
+[data-sparkle]::after {
+    content: "";
+    position: absolute;
+    inset: -120%;
+    background: linear-gradient(120deg, rgba(255, 255, 255, 0), rgba(255, 255, 255, 0.75), rgba(255, 255, 255, 0));
+    transform: rotate(12deg);
+    animation: shimmer 8s linear infinite;
+    pointer-events: none;
+    opacity: 0.35;
+}
+
+@keyframes shimmer {
+    0% {
+        transform: translateX(-60%) rotate(12deg);
+    }
+    100% {
+        transform: translateX(60%) rotate(12deg);
+    }
+}
+
+.procedural-art {
+    aspect-ratio: 16 / 10;
+    border-radius: var(--radius-medium);
+    overflow: hidden;
+    background: linear-gradient(140deg, rgba(59, 100, 255, 0.2), rgba(199, 210, 255, 0.4));
+    box-shadow: var(--shadow-soft);
+}
+
+.procedural-art img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+}
+
+@media (max-width: 960px) {
+    .hero {
+        grid-template-columns: 1fr;
+        padding: 4rem 1.25rem;
+    }
+
+    .hero::after {
+        inset: 1.5rem;
+    }
+
+    .hero__visual {
+        order: -1;
+        aspect-ratio: 3 / 2;
+    }
+
+    .nav__toggle {
+        display: inline-flex;
+    }
+
+    .nav__list {
+        position: absolute;
+        right: 0;
+        top: calc(100% + 0.75rem);
+        background: rgba(255, 255, 255, 0.95);
+        border-radius: var(--radius-medium);
+        box-shadow: var(--shadow-sharp);
+        padding: 1rem;
+        flex-direction: column;
+        align-items: flex-start;
+        min-width: 220px;
+        transform-origin: top right;
+        transform: scale(0.9);
+        opacity: 0;
+        visibility: hidden;
+        transition: opacity var(--transition), transform var(--transition), visibility var(--transition);
+    }
+
+    .nav__list.is-open {
+        transform: scale(1);
+        opacity: 1;
+        visibility: visible;
+    }
+}
+
+@media (max-width: 720px) {
+    main {
+        padding: 0 1.25rem 4rem;
+        gap: 3rem;
+    }
+
+    .section {
+        padding: 2rem;
+    }
+
+    .page__main {
+        padding: 3.5rem 1.25rem 4rem;
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+        animation-duration: 1ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: 1ms !important;
+        scroll-behavior: auto !important;
+    }
+
+    .reveal {
+        opacity: 1 !important;
+        transform: none !important;
+    }
+}

--- a/my-offline-site/index.html
+++ b/my-offline-site/index.html
@@ -1,0 +1,230 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Plateforme hors ligne élégante dédiée à la sécurité des IA : 25 domaines, méthodologies et outils pour anticiper les risques.">
+    <meta name="offline-ready" content="true">
+    <title>SafeIntelligence – Sécurité des IA</title>
+    <link rel="manifest" href="manifest.json">
+    <link rel="icon" type="image/svg+xml" href="assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <link rel="stylesheet" href="css/styles.css">
+    <script defer src="js/page-data.js"></script>
+    <script defer src="js/app.js"></script>
+    <script defer src="js/sw-register.js"></script>
+</head>
+<body>
+    <a class="skip-link" href="#main">Passer au contenu</a>
+    <header class="header" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                    <li><a href="index.html">Accueil</a></li>
+                    <li><a href="pages/alignment.html">Alignement</a></li>
+                    <li><a href="pages/interpretability.html">Interprétabilité</a></li>
+                    <li><a href="pages/governance.html">Gouvernance</a></li>
+                    <li><a href="pages/red-teaming.html">Red Teaming</a></li>
+                    <li><a href="pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+
+    <section class="hero" id="hero">
+        <canvas id="particle-canvas" aria-hidden="true"></canvas>
+        <div class="hero__content">
+            <p class="hero__kicker">Sécurité des intelligences artificielles</p>
+            <h1 class="hero__title">L'expérience hors ligne qui élève la résilience de vos IA.</h1>
+            <p class="hero__subtitle">Découvrez un parcours complet, élégant et opérationnel pour couvrir l'alignement, l'interprétabilité, la gouvernance et l'ensemble des disciplines critiques de la sécurité des IA.</p>
+            <div class="hero__cta">
+                <a class="btn" href="#sections">Explorer les domaines</a>
+                <button class="btn btn--ghost" data-scroll-target="#scenario">Composer une stratégie</button>
+            </div>
+            <ul class="badge-list" aria-label="Bénéfices clés">
+                <li>25 domaines d'expertise</li>
+                <li>Animations immersives</li>
+                <li>PWA 100% hors ligne</li>
+            </ul>
+        </div>
+        <div class="hero__visual" aria-hidden="true">
+            <div class="hero__visual-glow"></div>
+        </div>
+    </section>
+
+    <main id="main">
+        <section class="section section--grid reveal" id="sections" aria-labelledby="overview-title">
+            <div class="section__header">
+                <h2 id="overview-title">Un atlas raffiné des risques IA</h2>
+                <p>Nos 25 pages thématiques livrent une vision opérationnelle : cadrage stratégique, gouvernance, architecture, supervision et réponse aux incidents. Chaque sujet bénéficie d'illustrations génératives, de plans d'action et d'interactions guidées.</p>
+            </div>
+            <div class="topics-grid" role="list">
+                <a class="topic-card" role="listitem" href="pages/alignment.html">
+                    <h3>Alignement</h3>
+                    <p>Orchestrez des objectifs sûrs et contrôlables.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/interpretability.html">
+                    <h3>Interprétabilité</h3>
+                    <p>Exposez les décisions pour renforcer la confiance.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/scheming.html">
+                    <h3>Comportements stratégiques</h3>
+                    <p>Détectez les détours opportunistes et les dérives.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/robustness.html">
+                    <h3>Robustesse</h3>
+                    <p>Résistez aux perturbations et scénarios extrêmes.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/dataset-security.html">
+                    <h3>Sécurité des données</h3>
+                    <p>Préservez l'intégrité de vos jeux d'entraînement.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/oversight.html">
+                    <h3>Supervision humaine</h3>
+                    <p>Choregraphiez les boucles de validation critiques.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/governance.html">
+                    <h3>Gouvernance</h3>
+                    <p>Clarifiez rôles, contrôles et reporting.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/threat-modeling.html">
+                    <h3>Modélisation des menaces</h3>
+                    <p>Priorisez les efforts à forte valeur défensive.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/auditing.html">
+                    <h3>Audit des systèmes</h3>
+                    <p>Industrialisez la vérification des pipelines.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/transparency.html">
+                    <h3>Transparence</h3>
+                    <p>Partager sans trahir vos secrets industriels.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/monitoring.html">
+                    <h3>Surveillance continue</h3>
+                    <p>Captez les signaux faibles en temps réel.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/incident-response.html">
+                    <h3>Réponse aux incidents</h3>
+                    <p>Réagissez vite avec un plan orchestré.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/adversarial-learning.html">
+                    <h3>Apprentissage adversarial</h3>
+                    <p>Éprouvez vos modèles par le feu contrôlé.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/differential-privacy.html">
+                    <h3>Confidentialité différentielle</h3>
+                    <p>Formalisez la protection de chaque donnée.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/secure-architecture.html">
+                    <h3>Architecture sécurisée</h3>
+                    <p>Installez des garde-fous à chaque étage.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/human-in-the-loop.html">
+                    <h3>Humain dans la boucle</h3>
+                    <p>Composez des symbioses homme-machine efficaces.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/policy.html">
+                    <h3>Politiques internes</h3>
+                    <p>Diffusez une culture de sécurité unifiée.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/evaluation.html">
+                    <h3>Évaluations de sécurité</h3>
+                    <p>Mesurez la maturité et les progrès obtenus.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/red-teaming.html">
+                    <h3>Red Teaming IA</h3>
+                    <p>Dévoilez les failles avant l'adversaire.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/ethics.html">
+                    <h3>Éthique & sécurité</h3>
+                    <p>Alliez ambitions responsables et rigueur.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/supply-chain.html">
+                    <h3>Chaîne d'approvisionnement</h3>
+                    <p>Verrouillez dépendances, packages et APIs.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/hardware-security.html">
+                    <h3>Sécurité matérielle</h3>
+                    <p>Gardez le contrôle sur les accélérateurs IA.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/fail-safes.html">
+                    <h3>Mécanismes de repli</h3>
+                    <p>Préparez des arrêts gracieux et contrôlés.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/regulation.html">
+                    <h3>Régulation</h3>
+                    <p>Devancez les cadres internationaux.</p>
+                </a>
+                <a class="topic-card" role="listitem" href="pages/contact.html">
+                    <h3>Contact</h3>
+                    <p>Construisons votre programme sur mesure.</p>
+                </a>
+            </div>
+        </section>
+
+        <section class="section reveal" aria-labelledby="craft-title" data-sparkle>
+            <div class="section__header">
+                <h2 id="craft-title">Des parcours chorégraphiés pour chaque enjeu</h2>
+                <p>Animations discrètes, contrastes maîtrisés et contenus interactifs guident vos équipes à travers les décisions clés : cadrage, prévention, détection et réponse. L'expérience s'adapte à toutes les tailles d'écran sans dépendance à un réseau.</p>
+            </div>
+            <div class="gallery" aria-label="Illustrations génératives">
+                <figure class="gallery__item procedural-art">
+                    <img data-art="alignment" alt="Illustration générée sur l'alignement des IA">
+                    <figcaption class="gallery__legend">Alignement : des gradients doux symbolisent la convergence contrôlée des objectifs.</figcaption>
+                </figure>
+                <figure class="gallery__item procedural-art">
+                    <img data-art="robustness" alt="Illustration générée sur la robustesse des modèles">
+                    <figcaption class="gallery__legend">Robustesse : superposition de halos pour visualiser la résilience multicouche.</figcaption>
+                </figure>
+                <figure class="gallery__item procedural-art">
+                    <img data-art="governance" alt="Illustration générée sur la gouvernance IA">
+                    <figcaption class="gallery__legend">Gouvernance : architecture claire et hiérarchisée, inspirée des organigrammes premium.</figcaption>
+                </figure>
+            </div>
+        </section>
+
+        <section class="section reveal" id="scenario" aria-labelledby="scenario-title">
+            <div class="section__header">
+                <h2 id="scenario-title">Projetez votre feuille de route</h2>
+                <p>Utilisez le curseur pour découvrir les actions prioritaires à chaque étape de votre programme de sécurité IA. Les scénarios sont inspirés des pratiques que nous détaillons dans chacune des pages thématiques.</p>
+            </div>
+            <div class="scenario" data-scenario>
+                <div class="scenario__label">
+                    <span>Phase du programme</span>
+                    <span data-scenario-label>Exploration</span>
+                </div>
+                <input type="range" min="0" max="3" value="0" data-scenario-range aria-label="Sélectionnez la phase de votre programme">
+                <div class="scenario__output" aria-live="polite">
+                    <h3 data-scenario-title>Cartographier les risques</h3>
+                    <p data-scenario-text>Définissez les objectifs critiques, cadrez les cas d'usage et cartographiez les scénarios adverses pour éclairer vos priorités.</p>
+                </div>
+            </div>
+        </section>
+
+        <section class="section reveal" aria-labelledby="insight-title">
+            <div class="section__header">
+                <h2 id="insight-title">Signaux à suivre dans vos évaluations</h2>
+                <p>Les équipes peuvent activer ces déclencheurs d'analyse pour identifier rapidement un besoin d'audit ou de remédiation. Sélectionnez un signal pour découvrir nos recommandations.</p>
+            </div>
+            <div class="insight" data-insights-home>
+                <div class="insight__tabs" role="tablist" aria-label="Signaux de sécurité">
+                    <button type="button" role="tab" aria-selected="true" data-home-insight="alignement">Alignement</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="interpretabilite">Interprétabilité</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="robustesse">Robustesse</button>
+                    <button type="button" role="tab" aria-selected="false" data-home-insight="gouvernance">Gouvernance</button>
+                </div>
+                <div class="insight__panel" data-home-insight-panel aria-live="polite">
+                    Un modèle modifie ses réponses selon le type d'utilisateur ? Mesurez l'alignement comportemental à l'aide de jeux de tests scénarisés et enclenchez des revues humaines.
+                </div>
+            </div>
+        </section>
+    </main>
+
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence – Programme de résilience IA hors ligne.</p>
+        <p>Service worker cache-first, manifest PWA et animations 100% locales.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/js/app.js
+++ b/my-offline-site/js/app.js
@@ -1,0 +1,427 @@
+(() => {
+    const content = window.safeContent || {};
+    const prefersReducedMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+    const toggle = document.querySelector('.nav__toggle');
+    const list = document.querySelector('.nav__list');
+    if (toggle && list) {
+        toggle.addEventListener('click', () => {
+            const isOpen = list.classList.toggle('is-open');
+            toggle.setAttribute('aria-expanded', String(isOpen));
+        });
+
+        list.addEventListener('click', (event) => {
+            if (event.target instanceof HTMLElement && event.target.tagName === 'A') {
+                list.classList.remove('is-open');
+                toggle.setAttribute('aria-expanded', 'false');
+            }
+        });
+    }
+
+    document.querySelectorAll('[data-scroll-target]').forEach((button) => {
+        button.addEventListener('click', () => {
+            const selector = button.getAttribute('data-scroll-target');
+            if (!selector) return;
+            const target = document.querySelector(selector);
+            if (target) {
+                target.scrollIntoView({ behavior: prefersReducedMotion ? 'auto' : 'smooth' });
+            }
+        });
+    });
+
+    const header = document.querySelector('.header');
+    if (header) {
+        const updateHeader = () => {
+            if (window.scrollY > 24) {
+                header.classList.add('is-scrolled');
+            } else {
+                header.classList.remove('is-scrolled');
+            }
+        };
+        window.addEventListener('scroll', updateHeader, { passive: true });
+        updateHeader();
+    }
+
+    const revealElements = document.querySelectorAll('.reveal');
+    if (revealElements.length) {
+        const onIntersect = (entries, observer) => {
+            entries.forEach((entry) => {
+                if (entry.isIntersecting) {
+                    entry.target.classList.add('is-visible');
+                    observer.unobserve(entry.target);
+                }
+            });
+        };
+        if (!prefersReducedMotion && 'IntersectionObserver' in window) {
+            const observer = new IntersectionObserver(onIntersect, {
+                rootMargin: '0px 0px -10%',
+                threshold: 0.15,
+            });
+            revealElements.forEach((el) => observer.observe(el));
+        } else {
+            revealElements.forEach((el) => el.classList.add('is-visible'));
+        }
+    }
+
+    const canvas = document.getElementById('particle-canvas');
+    if (canvas && canvas instanceof HTMLCanvasElement && !prefersReducedMotion) {
+        const context = canvas.getContext('2d');
+        if (context) {
+            const particles = [];
+            const particleCount = 90;
+            const color = 'rgba(74, 111, 255, 0.55)';
+
+            const resize = () => {
+                canvas.width = canvas.clientWidth;
+                canvas.height = canvas.clientHeight;
+            };
+            resize();
+            window.addEventListener('resize', resize);
+
+            for (let i = 0; i < particleCount; i += 1) {
+                particles.push({
+                    x: Math.random() * canvas.width,
+                    y: Math.random() * canvas.height,
+                    radius: Math.random() * 2 + 0.6,
+                    velocityX: (Math.random() - 0.5) * 0.45,
+                    velocityY: (Math.random() - 0.5) * 0.45,
+                });
+            }
+
+            const draw = () => {
+                context.clearRect(0, 0, canvas.width, canvas.height);
+                particles.forEach((particle) => {
+                    context.beginPath();
+                    context.arc(particle.x, particle.y, particle.radius, 0, Math.PI * 2);
+                    context.fillStyle = color;
+                    context.fill();
+                });
+            };
+
+            const update = () => {
+                particles.forEach((particle) => {
+                    particle.x += particle.velocityX;
+                    particle.y += particle.velocityY;
+
+                    if (particle.x < 0 || particle.x > canvas.width) {
+                        particle.velocityX *= -1;
+                    }
+                    if (particle.y < 0 || particle.y > canvas.height) {
+                        particle.velocityY *= -1;
+                    }
+                });
+            };
+
+            const connect = () => {
+                for (let i = 0; i < particles.length; i += 1) {
+                    for (let j = i + 1; j < particles.length; j += 1) {
+                        const dx = particles[i].x - particles[j].x;
+                        const dy = particles[i].y - particles[j].y;
+                        const distance = Math.sqrt(dx * dx + dy * dy);
+                        if (distance < 150) {
+                            context.strokeStyle = `rgba(74, 111, 255, ${0.4 - distance / 360})`;
+                            context.lineWidth = 0.6;
+                            context.beginPath();
+                            context.moveTo(particles[i].x, particles[i].y);
+                            context.lineTo(particles[j].x, particles[j].y);
+                            context.stroke();
+                        }
+                    }
+                }
+            };
+
+            let animationId;
+            const animate = () => {
+                update();
+                draw();
+                connect();
+                animationId = window.requestAnimationFrame(animate);
+            };
+            animate();
+
+            document.addEventListener('visibilitychange', () => {
+                if (document.hidden) {
+                    window.cancelAnimationFrame(animationId);
+                } else {
+                    animationId = window.requestAnimationFrame(animate);
+                }
+            });
+        }
+    }
+
+    const scenarioData = [
+        {
+            label: 'Exploration',
+            title: 'Cartographier les risques',
+            text: "Identifiez les cas d'usage sensibles, recensez les données critiques et clarifiez les attentes métiers pour donner un cadre au programme de sécurité IA.",
+        },
+        {
+            label: 'Cadre',
+            title: 'Structurer la gouvernance',
+            text: "Mettre en place les comités, politiques et chartes qui encadrent l'usage des modèles et assignent les rôles de supervision.",
+        },
+        {
+            label: 'Déploiement',
+            title: 'Industrialiser les contrôles',
+            text: "Automatisez tests, évaluations et surveillance continue pour réduire les temps de réaction face aux signaux faibles.",
+        },
+        {
+            label: 'Optimisation',
+            title: 'Mesurer et améliorer',
+            text: "Consolidez vos indicateurs, partagez les leçons apprises et ajustez la feuille de route selon les incidents et retours terrain.",
+        },
+    ];
+
+    const scenarioRange = document.querySelector('[data-scenario-range]');
+    if (scenarioRange) {
+        const labelEl = document.querySelector('[data-scenario-label]');
+        const titleEl = document.querySelector('[data-scenario-title]');
+        const textEl = document.querySelector('[data-scenario-text]');
+        const updateScenario = (index) => {
+            const step = scenarioData[index] || scenarioData[0];
+            if (labelEl) labelEl.textContent = step.label;
+            if (titleEl) titleEl.textContent = step.title;
+            if (textEl) textEl.textContent = step.text;
+        };
+        scenarioRange.setAttribute('max', String(scenarioData.length - 1));
+        scenarioRange.addEventListener('input', (event) => {
+            const value = Number(event.target.value || 0);
+            updateScenario(value);
+        });
+        updateScenario(Number(scenarioRange.value || 0));
+    }
+
+    const homeInsights = {
+        alignement: "Un modèle modifie ses réponses selon le type d'utilisateur ? Mesurez l'alignement comportemental à l'aide de jeux de tests scénarisés et enclenchez des revues humaines.",
+        interpretabilite: "Les équipes peinent à expliquer une décision critique ? Réunissez data scientists et métier pour produire une narration accessible et archiver l'analyse.",
+        robustesse: "Vos stress tests révèlent des écarts extrêmes ? Priorisez les cas d'usage vitaux, ajoutez des protections en amont et surveillez la dérive.",
+        gouvernance: "Plusieurs équipes déploient des modèles sans validation ? Activez votre comité IA et imposez un pipeline approuvé avant mise en production.",
+    };
+    const homePanel = document.querySelector('[data-home-insight-panel]');
+    const homeButtons = document.querySelectorAll('[data-home-insight]');
+    if (homePanel && homeButtons.length) {
+        homeButtons.forEach((button) => {
+            button.addEventListener('click', () => {
+                homeButtons.forEach((other) => other.setAttribute('aria-selected', 'false'));
+                button.setAttribute('aria-selected', 'true');
+                const key = button.getAttribute('data-home-insight');
+                homePanel.textContent = homeInsights[key] || '';
+            });
+        });
+    }
+
+    const seedRandom = (seed) => {
+        let h = 0;
+        for (let i = 0; i < seed.length; i += 1) {
+            h = Math.imul(31, h) + seed.charCodeAt(i) | 0;
+        }
+        return () => {
+            h = Math.imul(h ^ h >>> 15, 1 | h);
+            h = h + Math.imul(h ^ h >>> 7, 61 | h) ^ h;
+            return ((h ^ h >>> 14) >>> 0) / 4294967296;
+        };
+    };
+
+    const drawRoundedRect = (ctx, x, y, width, height, radius) => {
+        const r = Math.min(radius, width / 2, height / 2);
+        ctx.beginPath();
+        ctx.moveTo(x + r, y);
+        ctx.lineTo(x + width - r, y);
+        ctx.quadraticCurveTo(x + width, y, x + width, y + r);
+        ctx.lineTo(x + width, y + height - r);
+        ctx.quadraticCurveTo(x + width, y + height, x + width - r, y + height);
+        ctx.lineTo(x + r, y + height);
+        ctx.quadraticCurveTo(x, y + height, x, y + height - r);
+        ctx.lineTo(x, y + r);
+        ctx.quadraticCurveTo(x, y, x + r, y);
+        ctx.closePath();
+    };
+
+    const createProceduralArt = (slug, palette, accent) => {
+        const canvasEl = document.createElement('canvas');
+        canvasEl.width = 960;
+        canvasEl.height = 600;
+        const ctx = canvasEl.getContext('2d');
+        if (!ctx) return '';
+
+        const random = seedRandom(slug);
+        const gradient = ctx.createLinearGradient(0, 0, canvasEl.width, canvasEl.height);
+        gradient.addColorStop(0, palette[0] || '#e8edff');
+        gradient.addColorStop(1, palette[1] || '#f6f8ff');
+        ctx.fillStyle = gradient;
+        ctx.fillRect(0, 0, canvasEl.width, canvasEl.height);
+
+        for (let i = 0; i < 8; i += 1) {
+            const cx = canvasEl.width * random();
+            const cy = canvasEl.height * random();
+            const radius = 180 + random() * 220;
+            const gradientCircle = ctx.createRadialGradient(cx, cy, radius * 0.1, cx, cy, radius);
+            gradientCircle.addColorStop(0, `${accent}33`);
+            gradientCircle.addColorStop(1, '#ffffff00');
+            ctx.fillStyle = gradientCircle;
+            ctx.beginPath();
+            ctx.arc(cx, cy, radius, 0, Math.PI * 2);
+            ctx.fill();
+        }
+
+        ctx.globalCompositeOperation = 'lighter';
+        for (let i = 0; i < 60; i += 1) {
+            const x1 = canvasEl.width * random();
+            const y1 = canvasEl.height * random();
+            const x2 = x1 + (random() - 0.5) * 220;
+            const y2 = y1 + (random() - 0.5) * 220;
+            ctx.strokeStyle = `${accent}${Math.floor(120 + random() * 80).toString(16)}`.slice(0, 7);
+            ctx.lineWidth = 1 + random() * 2;
+            ctx.beginPath();
+            ctx.moveTo(x1, y1);
+            ctx.quadraticCurveTo((x1 + x2) / 2 + random() * 120, (y1 + y2) / 2 + random() * 120, x2, y2);
+            ctx.stroke();
+        }
+        ctx.globalCompositeOperation = 'source-over';
+
+        ctx.lineWidth = 4;
+        ctx.strokeStyle = `${accent}80`;
+        for (let i = 0; i < 4; i += 1) {
+            const startX = canvasEl.width * random();
+            const startY = canvasEl.height * random();
+            const width = 180 + random() * 200;
+            const height = 90 + random() * 140;
+            drawRoundedRect(ctx, startX, startY, width, height, 42);
+            ctx.stroke();
+        }
+
+        return canvasEl.toDataURL('image/png');
+    };
+
+    const updateArtworks = () => {
+        document.querySelectorAll('img[data-art]').forEach((image) => {
+            const slug = image.getAttribute('data-art') || 'default';
+            const palette = content[slug]?.art?.palette || ['#e9eeff', '#f6f8ff'];
+            const accent = content[slug]?.art?.accent || '#3b64ff';
+            const dataUrl = createProceduralArt(slug, palette, accent);
+            if (dataUrl) {
+                image.src = dataUrl;
+            }
+        });
+    };
+    updateArtworks();
+
+    const topic = document.body?.dataset?.topic;
+    if (topic && content[topic]) {
+        const topicData = content[topic];
+        const metaDescription = document.querySelector('meta[name="description"]');
+        if (metaDescription) {
+            metaDescription.setAttribute('content', topicData.description);
+        }
+        if (document.title && !document.title.includes(topicData.title)) {
+            document.title = `${topicData.title} – Sécurité des IA`;
+        }
+
+        document.querySelectorAll('[data-field]').forEach((element) => {
+            const key = element.getAttribute('data-field');
+            if (key && typeof topicData[key] === 'string') {
+                element.textContent = topicData[key];
+            }
+        });
+
+        const narrativeGrid = document.querySelector('[data-narrative-grid]');
+        if (narrativeGrid) {
+            narrativeGrid.innerHTML = '';
+            topicData.narratives.forEach((item) => {
+                const block = document.createElement('article');
+                block.className = 'narrative-block';
+                const heading = document.createElement('h3');
+                heading.textContent = item.title;
+                block.appendChild(heading);
+                item.paragraphs.forEach((paragraph) => {
+                    const p = document.createElement('p');
+                    p.textContent = paragraph;
+                    block.appendChild(p);
+                });
+                narrativeGrid.appendChild(block);
+            });
+        }
+
+        const checklist = document.querySelector('[data-checklist]');
+        if (checklist) {
+            checklist.innerHTML = '';
+            topicData.checklist.forEach((item) => {
+                const li = document.createElement('li');
+                const text = document.createElement('p');
+                text.textContent = item;
+                li.appendChild(text);
+                checklist.appendChild(li);
+            });
+        }
+
+        const resources = document.querySelector('[data-resources]');
+        if (resources) {
+            resources.innerHTML = '';
+            topicData.resources.forEach((resource) => {
+                const li = document.createElement('li');
+                const link = document.createElement('a');
+                link.href = resource.href;
+                link.textContent = resource.label;
+                li.appendChild(link);
+                resources.appendChild(li);
+            });
+        }
+
+        const timelineRange = document.querySelector('[data-timeline-range]');
+        const timelineTitle = document.querySelector('[data-timeline-title]');
+        const timelineText = document.querySelector('[data-timeline-text]');
+        const updateTimeline = (index) => {
+            const item = topicData.timeline[index] || topicData.timeline[0];
+            if (timelineTitle) timelineTitle.textContent = item.label;
+            if (timelineText) timelineText.textContent = item.description;
+        };
+        if (timelineRange) {
+            timelineRange.setAttribute('max', String(topicData.timeline.length - 1));
+            timelineRange.addEventListener('input', (event) => {
+                const value = Number(event.target.value || 0);
+                updateTimeline(value);
+            });
+            updateTimeline(Number(timelineRange.value || 0));
+        }
+
+        const insightTabs = document.querySelector('[data-insight-tabs]');
+        const insightDisplay = document.querySelector('[data-insight-display]');
+        const applyInsight = (index) => {
+            const insight = topicData.insights[index] || topicData.insights[0];
+            if (insightDisplay) {
+                insightDisplay.textContent = insight.detail;
+            }
+        };
+        if (insightTabs && insightDisplay) {
+            insightTabs.innerHTML = '';
+            topicData.insights.forEach((insight, index) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.textContent = insight.label;
+                button.setAttribute('role', 'tab');
+                button.setAttribute('aria-selected', index === 0 ? 'true' : 'false');
+                button.addEventListener('click', () => {
+                    insightTabs.querySelectorAll('button').forEach((other) => other.setAttribute('aria-selected', 'false'));
+                    button.setAttribute('aria-selected', 'true');
+                    applyInsight(index);
+                });
+                insightTabs.appendChild(button);
+            });
+            applyInsight(0);
+        }
+
+        const randomButtons = document.querySelectorAll('[data-random-insight]');
+        if (randomButtons.length && topicData.insights.length) {
+            randomButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    const index = Math.floor(Math.random() * topicData.insights.length);
+                    if (insightTabs) {
+                        const buttons = insightTabs.querySelectorAll('button');
+                        buttons.forEach((btn, btnIndex) => btn.setAttribute('aria-selected', btnIndex === index ? 'true' : 'false'));
+                    }
+                    applyInsight(index);
+                });
+            });
+        }
+    }
+})();

--- a/my-offline-site/js/page-data.js
+++ b/my-offline-site/js/page-data.js
@@ -1,0 +1,1356 @@
+window.safeContent = {
+    "alignment": {
+        "title": "Alignement des IA",
+        "kicker": "Alignement stratégique",
+        "subtitle": "Coordonnez les intentions des modèles avec les valeurs de l'entreprise et la réglementation.",
+        "description": "Approches, signaux et garde-fous pour aligner les intelligences artificielles sur vos objectifs.",
+        "challenge": "Les objectifs implicites des modèles peuvent diverger des attentes humaines et créer des dommages collatéraux.",
+        "approach": "Formalisez des chartes d'entraînement, des tests d'alignement comportemental et des revues interfonctionnelles.",
+        "indicator": "Taux de non-conformité comportementale détecté par vos batteries de scénarios de tests contextualisés.",
+        "interactiveIntro": "Chaque étape d'un programme d'alignement renforce la granularité des garde-fous et la responsabilité partagée.",
+        "narratives": [
+            {
+                "title": "Tracer des frontières comportementales",
+                "paragraphs": [
+                    "L'alignement commence par la traduction des principes métiers et des exigences réglementaires en comportements mesurables. Cela implique de documenter les scénarios acceptables, les zones grises et les situations à bannir, puis de relier ces éléments aux jeux d'entraînement et aux données de renforcement.",
+                    "Les ateliers d'alignement gagnent en efficacité lorsqu'ils rassemblent métier, juridique, sécurité et utilisateurs finaux. Ensemble, ils établissent un lexique partagé pour qualifier la conformité des réponses générées et éviter les malentendus entre équipes."
+                ]
+            },
+            {
+                "title": "Institutionnaliser les revues humaines",
+                "paragraphs": [
+                    "Un programme mature prévoit des comités de décision qui évaluent régulièrement les compromis de performance versus alignement. Ils examinent les résultats de tests adversariaux, les journaux d'incidents et les feedbacks utilisateurs pour arbitrer les évolutions de modèles."
+                ]
+            },
+            {
+                "title": "Mesurer et corriger en continu",
+                "paragraphs": [
+                    "Les métriques d'alignement sont dynamiques : vous avez besoin de tableaux de bord qui associent scores comportementaux, couverture de tests et saturation des processus de validation humaine. Les seuils d'alerte doivent déclencher des boucles d'amélioration rapides."
+                ]
+            }
+        ],
+        "checklist": [
+            "Cartographier les principes éthiques et réglementaires applicables à chaque cas d'usage.",
+            "Développer des jeux de tests comportementaux contextualisés par segment utilisateur.",
+            "Mettre en place un comité d'arbitrage alignement/performance avec pouvoir décisionnel.",
+            "Documenter les incidents et dérives pour enrichir les règles d'entraînement et de déploiement."
+        ],
+        "timeline": [
+            {"label": "Exploration", "description": "Identifier les écarts potentiels entre objectifs métiers et apprentissage spontané du modèle."},
+            {"label": "Structuration", "description": "Créer des chartes d'alignement, formaliser les critères d'acceptation et les seuils d'alerte."},
+            {"label": "Opérationnalisation", "description": "Industrialiser les tests de régression, les revues humaines et les validations multi-équipes."},
+            {"label": "Maîtrise", "description": "Automatiser la détection des dérives et activer des plans de correction orchestrés en continu."}
+        ],
+        "insights": [
+            {"label": "Signal métier", "detail": "Des agents prennent des initiatives hors périmètre ? Revoyez les prompts systèmes et imposez des garde-fous d'autorisation."},
+            {"label": "Signal juridique", "detail": "Une recommandation enfreint un cadre réglementaire ? Programmez une suspension automatique du modèle concerné."},
+            {"label": "Signal utilisateur", "detail": "Les retours clients indiquent un ton inadapté ? Ajustez les données d'exemples et la pondération des objectifs."}
+        ],
+        "resources": [
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"}
+        ],
+        "art": {"palette": ["#dbe4ff", "#edf0ff", "#fafcff"], "accent": "#3b64ff"},
+        "artDescription": "Illustration générative évoquant la convergence de flux alignés."
+    },
+    "interpretability": {
+        "title": "Interprétabilité",
+        "kicker": "Transparence cognitive",
+        "subtitle": "Exposez les décisions algorithmiques pour faciliter l'audit et la confiance des parties prenantes.",
+        "description": "Techniques d'explicabilité, cartographies de features et protocoles de restitution pour vos IA.",
+        "challenge": "Sans transparence, impossible de comprendre ou de contester un résultat critique produit par le modèle.",
+        "approach": "Combinez interprétabilité intrinsèque, outils post-hoc et documentations de données pour couvrir tous les angles.",
+        "indicator": "Temps moyen nécessaire pour expliquer une décision critique à un auditeur externe.",
+        "interactiveIntro": "Chaque phase améliore la granularité des explications et la fluidité de vos restitutions.",
+        "narratives": [
+            {
+                "title": "Composer une carte de lecture",
+                "paragraphs": [
+                    "L'interprétabilité efficace repose sur une bibliothèque d'explications prêtes à être utilisées par différents publics. Elle inclut la traçabilité des données sources, l'importance des features et des exemples contrastifs pour illustrer les limites du modèle.",
+                    "Les ateliers de restitution doivent intégrer designers, data scientists et métiers afin de produire des narrations accessibles. L'objectif : livrer des explications courtes, visuelles et actionnables, compatibles avec la pression temporelle des incidents."
+                ]
+            },
+            {
+                "title": "Outiller les analystes",
+                "paragraphs": [
+                    "Les équipes d'investigation ont besoin de tableaux de bord interactifs permettant de rejouer des décisions, comparer des sorties alternatives et détecter des dépendances inattendues."
+                ]
+            },
+            {
+                "title": "Capitaliser sur les retours",
+                "paragraphs": [
+                    "Chaque demande d'explication doit enrichir la base documentaire. Les questions récurrentes révèlent des zones d'ombre que l'on peut éclairer avec de nouveaux scénarios de test et des fiches explicatives orientées métier."
+                ]
+            }
+        ],
+        "checklist": [
+            "Établir des personas d'audience pour calibrer les niveaux de détail attendus.",
+            "Associer à chaque modèle une fiche signalétique décrivant données, limites et responsables.",
+            "Mettre à disposition des notebooks reproductibles pour rejouer une décision sensible.",
+            "Garantir que les explications sont accessibles sur mobile et via des canaux hors ligne."
+        ],
+        "timeline": [
+            {"label": "Diagnostic", "description": "Inventorier les modèles critiques et leurs zones d'opacité."},
+            {"label": "Design", "description": "Concevoir les formats d'explications adaptés à chaque public."},
+            {"label": "Déploiement", "description": "Intégrer les outils d'explicabilité dans les workflows métiers."},
+            {"label": "Amélioration", "description": "Collecter les feedbacks et enrichir la bibliothèque d'exemples."}
+        ],
+        "insights": [
+            {"label": "Signal audit", "detail": "Une décision impactante est restée inexpliquée 48 h ? Escaladez automatiquement au comité d'éthique."},
+            {"label": "Signal produit", "detail": "Des variations de sortie inexpliquées augmentent ? Vérifiez la dérive des features et mettez à jour les dashboards."},
+            {"label": "Signal support", "detail": "Les équipes terrain réclament des supports papier ? Fournissez des fiches synthétiques hors ligne."}
+        ],
+        "resources": [
+            {"label": "Transparence", "href": "../pages/transparency.html"},
+            {"label": "Audit des systèmes", "href": "../pages/auditing.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#e0e9ff", "#cddcff"], "accent": "#566bff"},
+        "artDescription": "Illustration générative suggérant la décomposition d'une décision IA."
+    },
+    "governance": {
+        "title": "Gouvernance IA",
+        "kicker": "Capitainerie des risques",
+        "subtitle": "Établissez un pilotage clair, des rôles définis et des circuits de décision responsables.",
+        "description": "Modèles de gouvernance, comités, politiques et tableaux de bord pour sécuriser vos IA.",
+        "challenge": "Sans chaîne de responsabilité, la sécurité IA reste fragmentée et les incidents se multiplient.",
+        "approach": "Définissez des mandats précis, des politiques approuvées par la direction et des indicateurs de conformité.",
+        "indicator": "Pourcentage de décisions critiques disposant d'un propriétaire clairement identifié.",
+        "interactiveIntro": "La gouvernance s'étoffe d'abord par la définition des rôles, puis par des rituels et enfin par l'automatisation des contrôles.",
+        "narratives": [
+            {
+                "title": "Cartographier la chaîne décisionnelle",
+                "paragraphs": [
+                    "Une gouvernance solide débute par un organigramme de la responsabilité IA, couvrant sponsors, responsables produit, sécurité et juridique. Chaque acteur connaît ses droits, ses devoirs et la manière d'escalader un incident.",
+                    "Les chartes de gouvernance précisent également les niveaux d'approbation requis pour chaque changement de modèle. Elles s'accompagnent de matrices RACI et d'un calendrier de revues."
+                ]
+            },
+            {
+                "title": "Animer les comités",
+                "paragraphs": [
+                    "Les comités de pilotage examinent indicateurs de risque, incidents, dettes techniques et planifient les priorités. Ils arbitrent également les investissements nécessaires pour maintenir la conformité."
+                ]
+            },
+            {
+                "title": "Automatiser les contrôles",
+                "paragraphs": [
+                    "À maturité, la gouvernance intègre des workflows automatisés : demandes de changement, approbations électroniques, notifications en cas de dérive. Cela garantit une réaction rapide tout en conservant la traçabilité."
+                ]
+            }
+        ],
+        "checklist": [
+            "Identifier un sponsor exécutif responsable du programme IA.",
+            "Définir des rôles et responsabilités documentés pour chaque équipe.",
+            "Mettre en place un calendrier de comités avec ordres du jour standardisés.",
+            "Publier des indicateurs de conformité et des plans de remédiation suivis."
+        ],
+        "timeline": [
+            {"label": "Initialisation", "description": "Nommer les sponsors et recenser les modèles critiques."},
+            {"label": "Structuration", "description": "Formaliser les politiques, chartes et circuits d'approbation."},
+            {"label": "Animation", "description": "Faire vivre les comités et publier des rapports réguliers."},
+            {"label": "Optimisation", "description": "Automatiser les contrôles et intégrer la gouvernance dans les outils."}
+        ],
+        "insights": [
+            {"label": "Signal comité", "detail": "Des décisions sensibles sont prises hors comité ? Ajustez le processus d'approbation."},
+            {"label": "Signal indicateur", "detail": "Les KPI de conformité ne sont plus mis à jour ? Identifiez les dépendances bloquantes."},
+            {"label": "Signal équipe", "detail": "Les équipes ignorent qui alerter ? Diffusez des fiches réflexes et un annuaire responsives."}
+        ],
+        "resources": [
+            {"label": "Régulation", "href": "../pages/regulation.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#eaf0ff", "#f5f7ff", "#c8d7ff"], "accent": "#354cff"},
+        "artDescription": "Illustration générative structurée rappelant un organigramme épuré."
+    },
+    "red-teaming": {
+        "title": "Red Teaming IA",
+        "kicker": "Offensive contrôlée",
+        "subtitle": "Testez vos systèmes avec des attaques orchestrées pour découvrir les failles avant les adversaires.",
+        "description": "Méthodologies de red teaming, scripts adversariaux et reporting pour IA génératives et prédictives.",
+        "challenge": "Sans simulations réalistes, les vulnérabilités restent invisibles jusqu'à l'exploitation réelle.",
+        "approach": "Bâtissez une équipe multidisciplinaire, définissez des règles d'engagement et cadrez la restitution.",
+        "indicator": "Nombre de vulnérabilités découvertes en interne avant qu'elles ne soient signalées par l'extérieur.",
+        "interactiveIntro": "Le red teaming gagne en précision en passant de scénarios exploratoires à des campagnes orchestrées.",
+        "narratives": [
+            {
+                "title": "Construire des scénarios crédibles",
+                "paragraphs": [
+                    "Les exercices efficaces reproduisent des adversaires plausibles : insiders, concurrents, acteurs étatiques. Chaque scénario comporte des objectifs clairs et des règles d'engagement pour protéger la production.",
+                    "Documentez les hypothèses de menace, les contraintes techniques et les plans de retour arrière pour chaque campagne."
+                ]
+            },
+            {
+                "title": "Coordonner la réponse",
+                "paragraphs": [
+                    "Les tests sont utiles si les équipes de défense sont impliquées : elles apprennent à détecter, contenir et corriger en temps réel."
+                ]
+            },
+            {
+                "title": "Capitaliser sur les enseignements",
+                "paragraphs": [
+                    "Chaque exercice doit produire un plan d'action priorisé et mis à jour dans vos indicateurs de risque. Les succès comme les échecs alimentent votre veille."
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les objectifs et la portée de chaque campagne de red teaming.",
+            "Valider les règles d'engagement et les scénarios de repli avec les parties prenantes.",
+            "Documenter les scripts d'attaque pour les rejouer en formation.",
+            "Suivre la mise en œuvre des mesures correctives jusqu'à leur clôture."
+        ],
+        "timeline": [
+            {"label": "Préparation", "description": "Identifier les actifs critiques et définir les scénarios d'attaque."},
+            {"label": "Simulation", "description": "Exécuter les tests en impliquant les équipes défensives."},
+            {"label": "Analyse", "description": "Consolider les preuves et hiérarchiser les vulnérabilités."},
+            {"label": "Remédiation", "description": "Piloter la correction et re-tester pour vérifier la robustesse."}
+        ],
+        "insights": [
+            {"label": "Signal détection", "detail": "Les blue teams n'identifient pas l'attaque simulée ? Revisitez vos alertes et journaux."},
+            {"label": "Signal gouvernance", "detail": "Les recommandations restent ouvertes ? Ajoutez un sponsor exécutif pour lever les blocages."},
+            {"label": "Signal couverture", "detail": "Les scénarios ne couvrent que la génération de texte ? Ajoutez des tests sur les API et les modèles embarqués."}
+        ],
+        "resources": [
+            {"label": "Apprentissage adversarial", "href": "../pages/adversarial-learning.html"},
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#f0f3ff", "#d2dcff", "#b0c4ff"], "accent": "#2f5bff"},
+        "artDescription": "Illustration générative évoquant des trajectoires offensives contrôlées."
+    },
+    "contact": {
+        "title": "Contact & accompagnement",
+        "kicker": "Entrer en relation",
+        "subtitle": "Échangeons pour bâtir une feuille de route IA sécurisée adaptée à votre organisation.",
+        "description": "Coordonnées, ateliers et programme d'accompagnement pour renforcer la sécurité de vos IA.",
+        "challenge": "Les programmes réussis commencent par un diagnostic partagé des enjeux et des attentes.",
+        "approach": "Nous proposons des sessions d'écoute, d'audit express et de définition des priorités.",
+        "indicator": "Temps moyen entre la prise de contact et la mise en action du premier chantier prioritaire.",
+        "interactiveIntro": "Chaque échange renforce votre maturité : de la découverte à la co-construction d'un plan de transformation.",
+        "narratives": [
+            {
+                "title": "Comprendre votre contexte",
+                "paragraphs": [
+                    "Dès le premier rendez-vous, nous analysons vos cas d'usage, votre environnement réglementaire et vos contraintes techniques. L'objectif est de dresser un diagnostic rapide pour cibler les actions à fort impact.",
+                    "Vous repartez avec une synthèse structurée, incluant risques critiques, forces existantes et opportunités de sécurisation."
+                ]
+            },
+            {
+                "title": "Prototyper les solutions",
+                "paragraphs": [
+                    "Nos ateliers mêlent cadres méthodologiques et exercices pratiques : cartographie de risques, identification des dépendances, définition d'indicateurs. Nous co-concevons les premiers livrables pour accélérer votre mise en œuvre."
+                ]
+            },
+            {
+                "title": "Accompagner la transformation",
+                "paragraphs": [
+                    "Nous restons disponibles pour coacher vos équipes, orchestrer les revues de sécurité et faciliter les interactions avec vos partenaires externes."
+                ]
+            }
+        ],
+        "checklist": [
+            "Préparer une liste de cas d'usage IA prioritaires.",
+            "Identifier les parties prenantes à impliquer dans le diagnostic.",
+            "Réunir les politiques existantes et les indicateurs de risque.",
+            "Définir les attentes en matière de calendrier et de communication."
+        ],
+        "timeline": [
+            {"label": "Prise de contact", "description": "Planifier un échange et partager le contexte et les enjeux."},
+            {"label": "Diagnostic", "description": "Analyser les actifs, les risques majeurs et les dépendances."},
+            {"label": "Co-construction", "description": "Définir la feuille de route et prioriser les chantiers."},
+            {"label": "Suivi", "description": "Mesurer les résultats et ajuster la trajectoire avec vos équipes."}
+        ],
+        "insights": [
+            {"label": "Signal maturité", "detail": "Vous n'avez pas de tableau de bord de risques IA ? Nous pouvons en co-construire un en atelier."},
+            {"label": "Signal priorisation", "detail": "Trop d'initiatives concurrentes ? Nous facilitons l'arbitrage avec un modèle de scoring commun."},
+            {"label": "Signal collaboration", "detail": "Les métiers et la sécurité se parlent peu ? Nous proposons des rituels guidés pour aligner vos équipes."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#dce4ff", "#c1d4ff"], "accent": "#4a6cff"},
+        "artDescription": "Illustration générative évoquant une conversation structurée et lumineuse."
+    },
+    "adversarial-learning": {
+        "title": "Apprentissage adversarial",
+        "kicker": "Résilience entraînée",
+        "subtitle": "Exposez vos modèles à des attaques simulées pour améliorer leur résistance réelle.",
+        "description": "Techniques d'entraînement adversarial, sélection de perturbations et pilotage des performances.",
+        "challenge": "Les modèles non exposés aux attaques restent vulnérables à des perturbations minimes.",
+        "approach": "Alternez jeux de données propres et perturbés pour renforcer la stabilité tout en contrôlant la performance.",
+        "indicator": "Écart de performance entre données propres et données adversariales sur vos cas critiques.",
+        "interactiveIntro": "Chaque phase élargit le spectre des attaques simulées et la robustesse mesurée.",
+        "narratives": [
+            {
+                "title": "Définir les perturbations pertinentes",
+                "paragraphs": [
+                    "Cartographiez les menaces plausibles : bruit, prompt injection, modifications physiques. Associez chaque perturbation à un scénario métier prioritaire."
+                ]
+            },
+            {
+                "title": "Itérer sur les jeux d'entraînement",
+                "paragraphs": [
+                    "Maintenez un équilibre entre données originales et exemples adversariaux pour éviter la surcorrection. Ajustez les pondérations selon les risques constatés."
+                ]
+            },
+            {
+                "title": "Suivre la performance",
+                "paragraphs": [
+                    "Publiez des rapports combinant précision standard, robustesse et coût de calcul pour éclairer les arbitrages." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Lister les menaces adversariales propres à vos usages.",
+            "Constituer un catalogue de perturbations reproductibles.",
+            "Automatiser les tests de robustesse après chaque déploiement.",
+            "Suivre l'impact sur la performance métier et ajuster les métriques."
+        ],
+        "timeline": [
+            {"label": "Exploration", "description": "Identifier les attaques et collecter des exemples pertinents."},
+            {"label": "Expérimentation", "description": "Former des modèles avec des lots adversariaux et mesurer l'impact."},
+            {"label": "Industrialisation", "description": "Intégrer les tests adversariaux dans la CI/CD."},
+            {"label": "Optimisation", "description": "Adapter les budgets de calcul et les seuils de déclenchement."}
+        ],
+        "insights": [
+            {"label": "Signal modèle", "detail": "Une légère perturbation change la prédiction ? Ajoutez cette attaque à votre pipeline d'entraînement."},
+            {"label": "Signal monitoring", "detail": "Les attaques simulées déclenchent peu d'alertes ? Ajustez vos seuils de détection."},
+            {"label": "Signal coût", "detail": "Les coûts explosent lors des entraînements adversariaux ? Priorisez les cas d'usage critiques."}
+        ],
+        "resources": [
+            {"label": "Robustesse", "href": "../pages/robustness.html"},
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#ecf1ff", "#d1deff", "#b7ccff"], "accent": "#3757ff"},
+        "artDescription": "Illustration générative évoquant des ondes protectrices."
+    },
+    "auditing": {
+        "title": "Audit des systèmes IA",
+        "kicker": "Contrôle exigeant",
+        "subtitle": "Structurez des audits réguliers couvrant données, modèles, déploiement et opérations.",
+        "description": "Cadres d'audit IA, checklists et rapports pour démontrer la conformité et la maîtrise des risques.",
+        "challenge": "Sans audit, impossible de prouver la conformité ou de détecter une dérive silencieuse.",
+        "approach": "Planifiez des audits multi-disciplinaires, harmonisez les référentiels et publiez les écarts.",
+        "indicator": "Nombre d'audits critiques réalisés et suivis jusqu'à clôture des actions.",
+        "interactiveIntro": "Les audits passent d'un diagnostic ponctuel à un programme continu, assisté par des outils.",
+        "narratives": [
+            {
+                "title": "Définir le périmètre",
+                "paragraphs": [
+                    "Identifiez les modèles prioritaires, les réglementations applicables et les points de contrôle indispensables pour structurer votre audit."
+                ]
+            },
+            {
+                "title": "Collecter les preuves",
+                "paragraphs": [
+                    "Centralisez logs, jeux de données de référence et documents de décision pour accélérer la revue et limiter la charge opérationnelle."
+                ]
+            },
+            {
+                "title": "Piloter les plans d'action",
+                "paragraphs": [
+                    "Chaque écart détecté doit être affecté à un responsable avec un délai clair, afin de garantir la remédiation et éviter la récurrence."
+                ]
+            }
+        ],
+        "checklist": [
+            "Établir un calendrier d'audit basé sur le risque.",
+            "Documenter les contrôles et leurs sources de preuve.",
+            "Assigner des responsables et des dates de remédiation.",
+            "Partager un rapport synthétique avec les parties prenantes."
+        ],
+        "timeline": [
+            {"label": "Planification", "description": "Sélectionner les systèmes à auditer et préparer les outils."},
+            {"label": "Exécution", "description": "Collecter les preuves et mener les entretiens."},
+            {"label": "Analyse", "description": "Hiérarchiser les écarts et proposer des actions."},
+            {"label": "Suivi", "description": "Vérifier la clôture des mesures et capitaliser dans le référentiel."}
+        ],
+        "insights": [
+            {"label": "Signal conformité", "detail": "Un audit n'a pas été réalisé depuis 12 mois ? Programmez une mission flash."},
+            {"label": "Signal documentation", "detail": "Les preuves sont dispersées ? Implémentez un coffre-fort documentaire."},
+            {"label": "Signal gouvernance", "detail": "Les plans d'action stagnent ? Escaladez au comité de gouvernance."}
+        ],
+        "resources": [
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f5f7ff", "#dde5ff", "#c5d4ff"], "accent": "#3c5cff"},
+        "artDescription": "Illustration générative rappelant un classeur d'audit raffiné."
+    },
+    "dataset-security": {
+        "title": "Sécurité des jeux de données",
+        "kicker": "Intégrité des données",
+        "subtitle": "Protégez la collecte, la gouvernance et la distribution de vos données d'entraînement.",
+        "description": "Stratégies de sécurisation, contrôles d'accès et observabilité pour les jeux de données IA.",
+        "challenge": "Des données compromises entraînent des modèles biaisés ou manipulés.",
+        "approach": "Appliquez segmentation, contrôle d'accès fin et surveillance des contributions externes.",
+        "indicator": "Taux d'anomalies détectées dans les flux de données d'entraînement.",
+        "interactiveIntro": "La sécurité des données s'étend des sources à la gouvernance continue.",
+        "narratives": [
+            {
+                "title": "Renforcer la collecte",
+                "paragraphs": [
+                    "Sécurisez les pipelines de collecte avec des signatures, des validations syntaxiques et des contrôles de provenance pour empêcher les empoisonnements." 
+                ]
+            },
+            {
+                "title": "Tracer chaque contribution",
+                "paragraphs": [
+                    "Documentez les métadonnées des contributeurs, des transformations et des validations réalisées. Vous créez ainsi une piste d'audit exploitable lors des enquêtes." 
+                ]
+            },
+            {
+                "title": "Superviser la diffusion",
+                "paragraphs": [
+                    "Distribuez les données via des canaux contrôlés avec chiffrement, empreintes et suivis d'accès pour prévenir les fuites et modifications non autorisées." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir des niveaux de sensibilité pour chaque source de données.",
+            "Mettre en place des contrôles de qualité automatisés.",
+            "Isoler les environnements d'ingestion et de validation.",
+            "Auditer régulièrement les accès et les contributions externes."
+        ],
+        "timeline": [
+            {"label": "Collecte", "description": "Sécuriser les sources et les flux entrants."},
+            {"label": "Gouvernance", "description": "Documenter les métadonnées et les droits d'usage."},
+            {"label": "Distribution", "description": "Assurer des canaux sûrs et traçables."},
+            {"label": "Surveillance", "description": "Détecter les anomalies et les tentatives de corruption."}
+        ],
+        "insights": [
+            {"label": "Signal intégrité", "detail": "Des jeux contiennent des valeurs inattendues ? Enclenchez une analyse de contamination."},
+            {"label": "Signal accès", "detail": "Des accès hors horaires apparaissent ? Vérifiez les comptes à privilèges."},
+            {"label": "Signal provenance", "detail": "Une source n'est plus traçable ? Bloquez son usage jusqu'à clarification."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Confidentialité différentielle", "href": "../pages/differential-privacy.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"}
+        ],
+        "art": {"palette": ["#edf2ff", "#d3ddff", "#bed0ff"], "accent": "#4369ff"},
+        "artDescription": "Illustration générative représentant des couches de données protégées."
+    },
+    "differential-privacy": {
+        "title": "Confidentialité différentielle",
+        "kicker": "Protection mathématique",
+        "subtitle": "Appliquez des garanties formelles pour partager des insights sans exposer d'individu.",
+        "description": "Concepts, paramètres epsilon/delta et stratégies d'implémentation pour la confidentialité différentielle.",
+        "challenge": "Sans garanties mathématiques, chaque analyse peut divulguer une donnée personnelle.",
+        "approach": "Calibrez le budget de confidentialité et formez les équipes au raisonnement probabiliste.",
+        "indicator": "Budget de confidentialité consommé par rapport au budget alloué.",
+        "interactiveIntro": "La confidentialité différentielle exige une montée en compétence progressive et des contrôles outillés.",
+        "narratives": [
+            {
+                "title": "Sensibiliser aux concepts",
+                "paragraphs": [
+                    "Expliquez les notions d'epsilon, delta et bruit calibré à vos parties prenantes. Utilisez des exemples concrets pour démystifier la perte d'information et rassurer sur la valeur métier." 
+                ]
+            },
+            {
+                "title": "Intégrer les outils",
+                "paragraphs": [
+                    "Choisissez des bibliothèques fiables, définissez des politiques de budget et tracez chaque requête exécutée pour conserver une traçabilité irréprochable." 
+                ]
+            },
+            {
+                "title": "Superviser le budget",
+                "paragraphs": [
+                    "Publiez un tableau de bord montrant la consommation du budget de confidentialité et les alertes automatiques lorsqu'un seuil est atteint." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Former les équipes métier et data science à la confidentialité différentielle.",
+            "Définir des budgets par cas d'usage et par période.",
+            "Mettre en place des outils de suivi de la consommation.",
+            "Documenter les exceptions et obtenir des validations juridiques."
+        ],
+        "timeline": [
+            {"label": "Sensibilisation", "description": "Diffuser les concepts et les bénéfices."},
+            {"label": "Pilote", "description": "Expérimenter sur un jeu de données limité."},
+            {"label": "Déploiement", "description": "Généraliser la confidentialité différentielle aux analyses sensibles."},
+            {"label": "Gouvernance", "description": "Surveiller le budget et auditer les exceptions."}
+        ],
+        "insights": [
+            {"label": "Signal juridique", "detail": "Une demande de dérogation se multiplie ? Recalibrez votre budget et vos cas d'usage."},
+            {"label": "Signal data", "detail": "Les data scientists ajustent souvent epsilon ? Proposez des modèles d'analyse alternatifs."},
+            {"label": "Signal produit", "detail": "Les utilisateurs perçoivent trop de bruit ? Expliquez la balance entre confidentialité et précision."}
+        ],
+        "resources": [
+            {"label": "Sécurité des données", "href": "../pages/dataset-security.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Régulation", "href": "../pages/regulation.html"}
+        ],
+        "art": {"palette": ["#f4f7ff", "#e2eaff", "#ccd9ff"], "accent": "#4a62ff"},
+        "artDescription": "Illustration générative symbolisant un voile protecteur mathématique."
+    },
+    "ethics": {
+        "title": "Éthique & sécurité",
+        "kicker": "Responsabilité augmentée",
+        "subtitle": "Ancrez vos programmes IA dans des valeurs claires et des pratiques responsables.",
+        "description": "Cadres éthiques, comités, évaluations d'impact et liens avec la sécurité IA.",
+        "challenge": "Sans garde-fous éthiques, la sécurité peut entrer en conflit avec la confiance du public.",
+        "approach": "Associez les disciplines éthique, juridique et sécurité pour co-construire les principes directeurs.",
+        "indicator": "Nombre de décisions revues par le comité éthique-sécurité et acceptées sans réserve.",
+        "interactiveIntro": "L'éthique se matérialise progressivement par des standards, des évaluations et des arbitrages transparents.",
+        "narratives": [
+            {
+                "title": "Aligner valeurs et contrôle",
+                "paragraphs": [
+                    "Formalisez des principes éthiques qui guident la conception, l'entraînement et l'exploitation des modèles. Ces principes doivent être audités et reliés aux objectifs de sécurité." 
+                ]
+            },
+            {
+                "title": "Évaluer les impacts",
+                "paragraphs": [
+                    "Réalisez des évaluations d'impact socio-technique avant chaque déploiement majeur pour identifier les risques de biais, d'exclusion ou de manipulation." 
+                ]
+            },
+            {
+                "title": "Gouverner les arbitrages",
+                "paragraphs": [
+                    "Documentez les décisions sensibles, assurez une traçabilité et communiquez les arbitrages aux parties prenantes internes et externes." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Créer un comité éthique-sécurité avec pouvoirs décisionnels.",
+            "Mettre à jour régulièrement la charte éthique et la diffuser.",
+            "Suivre les indicateurs d'équité, d'inclusion et de sécurité.",
+            "Prévoir des canaux de signalement accessibles et anonymes."
+        ],
+        "timeline": [
+            {"label": "Principes", "description": "Définir les valeurs et les engagements."},
+            {"label": "Cadres", "description": "Mettre en place chartes et évaluations d'impact."},
+            {"label": "Opérations", "description": "Accompagner les projets et arbitrer les dilemmes."},
+            {"label": "Transparence", "description": "Publier les décisions et les enseignements."}
+        ],
+        "insights": [
+            {"label": "Signal réputation", "detail": "Un incident médiatique survient ? Activez une cellule éthique-sécurité pour répondre vite."},
+            {"label": "Signal inclusion", "detail": "Des communautés se disent exclues ? Ajustez vos jeux de données et vos processus d'audit."},
+            {"label": "Signal gouvernance", "detail": "Les décisions éthiques sont floues ? Clarifiez les rôles et documentez chaque arbitrage."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"}
+        ],
+        "art": {"palette": ["#f7f9ff", "#e7efff", "#d3e1ff"], "accent": "#4a6bff"},
+        "artDescription": "Illustration générative représentant un équilibre harmonieux."
+    },
+    "evaluation": {
+        "title": "Évaluations de sécurité",
+        "kicker": "Performance contrôlée",
+        "subtitle": "Mesurez la résilience de vos IA avec des protocoles structurés.",
+        "description": "Cadres d'évaluation, métriques et orchestrations pour suivre la sécurité IA.",
+        "challenge": "Sans évaluation régulière, les mesures de sécurité restent théoriques.",
+        "approach": "Définissez des indicateurs alignés aux risques et automatisez la collecte des preuves.",
+        "indicator": "Taux de couverture des scénarios de tests critiques.",
+        "interactiveIntro": "Les évaluations montent en puissance au fil de la consolidation des données et des outils.",
+        "narratives": [
+            {
+                "title": "Cartographier les scénarios",
+                "paragraphs": [
+                    "Identifiez les risques majeurs par modèle et associez-leur des scénarios d'évaluation priorisés. Chaque scénario doit reproduire un incident plausible et des critères de succès mesurables." 
+                ]
+            },
+            {
+                "title": "Industrialiser la mesure",
+                "paragraphs": [
+                    "Collectez automatiquement les logs, comparez les résultats et publiez des tableaux de bord de sécurité accessibles aux décideurs comme aux opérationnels." 
+                ]
+            },
+            {
+                "title": "Boucler sur l'amélioration",
+                "paragraphs": [
+                    "Partagez les leçons apprises et mettez à jour les scénarios selon les incidents observés et les retours terrain." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Inventorier les scénarios critiques par modèle.",
+            "Associer un indicateur et un seuil par risque.",
+            "Automatiser l'exécution des tests et la collecte des preuves.",
+            "Publier un rapport régulier aux parties prenantes."
+        ],
+        "timeline": [
+            {"label": "Cadre", "description": "Définir les métriques et la gouvernance de l'évaluation."},
+            {"label": "Instrumentation", "description": "Mettre en place les outils de collecte et d'analyse."},
+            {"label": "Diffusion", "description": "Communiquer les résultats et les alertes."},
+            {"label": "Optimisation", "description": "Ajuster les scénarios et intégrer les retours."}
+        ],
+        "insights": [
+            {"label": "Signal dérive", "detail": "Une métrique dépasse son seuil ? Déclenchez une revue immédiate."},
+            {"label": "Signal saturation", "detail": "Les équipes n'arrivent pas à suivre les évaluations ? Priorisez selon la criticité."},
+            {"label": "Signal qualité", "detail": "Des tests échouent sans explication ? Vérifiez la stabilité des jeux de référence."}
+        ],
+        "resources": [
+            {"label": "Audit des systèmes", "href": "../pages/auditing.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Mécanismes de repli", "href": "../pages/fail-safes.html"}
+        ],
+        "art": {"palette": ["#f0f4ff", "#dbe4ff", "#c6d8ff"], "accent": "#3b5eff"},
+        "artDescription": "Illustration générative inspirée d'un tableau de bord élégant."
+    },
+    "fail-safes": {
+        "title": "Mécanismes de repli",
+        "kicker": "Arrêts gracieux",
+        "subtitle": "Planifiez des solutions de secours pour contenir les dérives des IA.",
+        "description": "Stratégies de fallback, procédures d'arrêt et communication de crise.",
+        "challenge": "Sans plan de repli, une dérive peut se transformer en incident majeur.",
+        "approach": "Préparez des modes dégradés, des procédures d'arrêt et des scénarios de substitution.",
+        "indicator": "Temps nécessaire pour activer un fallback et revenir à une situation sûre.",
+        "interactiveIntro": "Les replis évoluent d'un simple bouton d'arrêt vers des modes dégradés orchestrés.",
+        "narratives": [
+            {
+                "title": "Identifier les garde-fous",
+                "paragraphs": [
+                    "Cartographiez les points de décision critiques et définissez les conditions qui imposent un arrêt ou un basculement manuel." 
+                ]
+            },
+            {
+                "title": "Préparer les modes dégradés",
+                "paragraphs": [
+                    "Concevez des alternatives manuelles, semi-automatiques ou basées sur des modèles plus simples afin de maintenir le service minimal." 
+                ]
+            },
+            {
+                "title": "Tester régulièrement",
+                "paragraphs": [
+                    "Les mécanismes de repli doivent être testés comme un plan de continuité. Simulez des déclenchements pour vérifier la préparation des équipes." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Lister les scénarios de dérive nécessitant un arrêt.",
+            "Définir la responsabilité de déclenchement du repli.",
+            "Maintenir des scripts ou procédures à jour.",
+            "Communiquer les impacts aux parties prenantes en cas d'activation."
+        ],
+        "timeline": [
+            {"label": "Identification", "description": "Déterminer les points de contrôle et les scénarios d'arrêt."},
+            {"label": "Conception", "description": "Définir les modes dégradés et les procédures."},
+            {"label": "Test", "description": "Simuler les déclenchements et vérifier la réactivité."},
+            {"label": "Amélioration", "description": "Capitaliser sur les retours d'expérience."}
+        ],
+        "insights": [
+            {"label": "Signal fatigue", "detail": "Les équipes hésitent à déclencher le repli ? Clarifiez les critères et assurez la protection juridique."},
+            {"label": "Signal technique", "detail": "Les scripts de fallback sont obsolètes ? Automatisez les tests réguliers."},
+            {"label": "Signal communication", "detail": "Les parties prenantes découvrent l'incident par hasard ? Élaborez des messages pré-approvés."}
+        ],
+        "resources": [
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#eef3ff", "#d4defe", "#bccdff"], "accent": "#4562ff"},
+        "artDescription": "Illustration générative représentant un atterrissage contrôlé."
+    },
+    "hardware-security": {
+        "title": "Sécurité matérielle",
+        "kicker": "Infrastructure blindée",
+        "subtitle": "Protégez les accélérateurs IA, racks et environnements physiques.",
+        "description": "Mesures physiques, firmware et monitoring pour une infrastructure IA sécurisée.",
+        "challenge": "Les attaques matérielles peuvent contourner toutes les protections logicielles.",
+        "approach": "Segmenter, surveiller et attester vos équipements pour garantir leur intégrité.",
+        "indicator": "Taux d'équipements avec attestation de démarrage vérifiée.",
+        "interactiveIntro": "La sécurité matérielle progresse du verrouillage physique vers des chaînes d'attestation complètes.",
+        "narratives": [
+            {
+                "title": "Contrôler l'accès physique",
+                "paragraphs": [
+                    "Protégez les datacenters, tracez les entrées et surveillez en continu les zones sensibles via des capteurs et badges intelligents." 
+                ]
+            },
+            {
+                "title": "Sécuriser le firmware",
+                "paragraphs": [
+                    "Appliquez les mises à jour, vérifiez l'intégrité et conservez des images de référence pour rétablir rapidement les composants compromis." 
+                ]
+            },
+            {
+                "title": "Superviser la chaîne d'approvisionnement",
+                "paragraphs": [
+                    "Suivez les numéros de série, les certificats et les interventions de maintenance pour garder un historique fiable de chaque équipement." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Mettre en place une gestion des accès physiques stricte.",
+            "Documenter et vérifier les mises à jour firmware.",
+            "Installer des capteurs anti-intrusion et de température.",
+            "Planifier des audits réguliers de la chaîne matérielle."
+        ],
+        "timeline": [
+            {"label": "Contrôle d'accès", "description": "Protéger les zones sensibles et tracer les entrées."},
+            {"label": "Durcissement", "description": "Assurer les mises à jour et la configuration sécurisée."},
+            {"label": "Attestation", "description": "Déployer des mécanismes de vérification d'intégrité."},
+            {"label": "Supervision", "description": "Surveiller en temps réel et auditer la chaîne matérielle."}
+        ],
+        "insights": [
+            {"label": "Signal capteur", "detail": "Une variation thermique soudaine ? Vérifiez l'environnement et les accès."},
+            {"label": "Signal firmware", "detail": "Un firmware non signé est détecté ? Isolez l'équipement et réinstallez l'image certifiée."},
+            {"label": "Signal logistique", "detail": "Un composant arrive sans traçabilité ? Bloquez son intégration."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"}
+        ],
+        "art": {"palette": ["#e9f0ff", "#d1dfff", "#b8ceff"], "accent": "#3a5fff"},
+        "artDescription": "Illustration générative évoquant une forteresse matérielle."
+    },
+    "human-in-the-loop": {
+        "title": "Humain dans la boucle",
+        "kicker": "Synergie supervisée",
+        "subtitle": "Organisez des interactions fluides entre opérateurs et modèles IA.",
+        "description": "Processus, outils et ergonomie pour intégrer l'humain dans les boucles de décision.",
+        "challenge": "Sans implication humaine, les dérives passent inaperçues et la confiance s'érode.",
+        "approach": "Définissez les points de validation humaine, équipez les opérateurs et mesurez leur charge.",
+        "indicator": "Temps médian de validation humaine et taux d'escalade.",
+        "interactiveIntro": "L'humain devient partenaire du modèle à mesure que les outils facilitent la collaboration.",
+        "narratives": [
+            {
+                "title": "Designer les points de contrôle",
+                "paragraphs": [
+                    "Identifiez où l'intervention humaine apporte le plus de valeur et formalisez le rôle des opérateurs pour éviter la fatigue décisionnelle." 
+                ]
+            },
+            {
+                "title": "Équiper les opérateurs",
+                "paragraphs": [
+                    "Fournissez des interfaces claires, des explications accessibles et des options de correction rapide afin d'accélérer leurs décisions." 
+                ]
+            },
+            {
+                "title": "Mesurer la collaboration",
+                "paragraphs": [
+                    "Suivez le temps passé, les types d'escalade et la satisfaction des équipes pour ajuster les workflows et équilibrer la charge." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les responsabilités des opérateurs humains.",
+            "Fournir des interfaces accessibles et responsives.",
+            "Former les équipes sur les signaux de dérive.",
+            "Mesurer la charge et ajuster les effectifs."
+        ],
+        "timeline": [
+            {"label": "Cadrage", "description": "Identifier les interactions clés et les responsabilités."},
+            {"label": "Design", "description": "Créer des interfaces et protocoles de validation."},
+            {"label": "Déploiement", "description": "Former les opérateurs et lancer les workflows."},
+            {"label": "Amélioration", "description": "Analyser les retours et ajuster la collaboration."}
+        ],
+        "insights": [
+            {"label": "Signal fatigue", "detail": "Les opérateurs passent trop de temps à corriger ? Rebalancez la charge ou automatisez davantage."},
+            {"label": "Signal confiance", "detail": "Les validations humaines sont systématiquement acceptées ? Vérifiez la pertinence des seuils."},
+            {"label": "Signal ergonomie", "detail": "Les opérateurs quittent l'interface ? Simplifiez les interactions et supportez les terminaux mobiles."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#dfe9ff", "#c6d9ff"], "accent": "#4b63ff"},
+        "artDescription": "Illustration générative illustrant la collaboration homme-machine."
+    },
+    "incident-response": {
+        "title": "Réponse aux incidents IA",
+        "kicker": "Précision tactique",
+        "subtitle": "Préparez vos équipes à gérer et résoudre les incidents IA avec assurance.",
+        "description": "Plans de réponse, communication de crise et post-mortems adaptés aux incidents IA.",
+        "challenge": "Les incidents IA demandent des réflexes spécifiques souvent absents des plans classiques.",
+        "approach": "Adaptez vos plans de réponse et entraînez vos équipes à ces nouveaux scénarios.",
+        "indicator": "Temps moyen de détection et de résolution d'un incident IA.",
+        "interactiveIntro": "La réponse gagne en efficacité en combinant procédures, simulation et retour d'expérience.",
+        "narratives": [
+            {
+                "title": "Adapter les plans existants",
+                "paragraphs": [
+                    "Intégrez les scénarios IA à votre plan de réponse global, en précisant les déclencheurs spécifiques et les responsables de chaque action." 
+                ]
+            },
+            {
+                "title": "Entraîner les équipes",
+                "paragraphs": [
+                    "Organisez des exercices réguliers impliquant métiers, sécurité et communication pour tester la coordination et la rapidité d'exécution." 
+                ]
+            },
+            {
+                "title": "Capitaliser après l'incident",
+                "paragraphs": [
+                    "Réalisez des post-mortems, collectez les indicateurs et mettez à jour les contrôles afin d'éviter les récidives." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Documenter les scénarios d'incidents IA probables.",
+            "Définir les rôles de chaque équipe lors d'un incident.",
+            "Préparer des messages de communication pré-validés.",
+            "Suivre les actions correctives jusqu'à leur clôture."
+        ],
+        "timeline": [
+            {"label": "Préparation", "description": "Créer les playbooks et les équipes d'astreinte."},
+            {"label": "Détection", "description": "Mettre en place les capteurs et seuils d'alerte."},
+            {"label": "Réponse", "description": "Coordonner les actions techniques et la communication."},
+            {"label": "Amélioration", "description": "Analyser l'incident et renforcer les contrôles."}
+        ],
+        "insights": [
+            {"label": "Signal coordination", "detail": "Les messages se contredisent ? Centralisez la communication et attribuez un porte-parole."},
+            {"label": "Signal détection", "detail": "L'incident a été découvert par un client ? Renforcez vos alertes internes et vos métriques."},
+            {"label": "Signal post-mortem", "detail": "Les leçons ne sont pas suivies ? Affectez des responsables et des échéances."}
+        ],
+        "resources": [
+            {"label": "Mécanismes de repli", "href": "../pages/fail-safes.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#eef2ff", "#d6e0ff", "#bccdff"], "accent": "#3f5fff"},
+        "artDescription": "Illustration générative illustrant une intervention maîtrisée."
+    },
+    "monitoring": {
+        "title": "Surveillance continue",
+        "kicker": "Sentinelle proactive",
+        "subtitle": "Détectez les dérives et incidents IA en temps réel.",
+        "description": "Capteurs, métriques et opérations pour une surveillance IA 24/7.",
+        "challenge": "Sans surveillance, une dérive peut durer des jours avant d'être détectée.",
+        "approach": "Déployez des capteurs adaptés, des seuils intelligents et des équipes en alerte.",
+        "indicator": "Temps médian de détection d'une anomalie IA.",
+        "interactiveIntro": "La surveillance gagne en précision avec des signaux multiples et des workflows intégrés.",
+        "narratives": [
+            {
+                "title": "Instrumenter les signaux",
+                "paragraphs": [
+                    "Combinez logs applicatifs, métriques métier et signaux utilisateur pour détecter les anomalies avant qu'elles n'affectent vos clients." 
+                ]
+            },
+            {
+                "title": "Automatiser les alertes",
+                "paragraphs": [
+                    "Mettez en place des seuils dynamiques, des corrélations et des notifications multi-canaux afin d'éviter la fatigue d'alerte." 
+                ]
+            },
+            {
+                "title": "Boucler avec les équipes",
+                "paragraphs": [
+                    "Assurez une prise en charge rapide grâce à des rotations d'astreinte, des runbooks et des tableaux de bord partagés." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les signaux critiques par modèle.",
+            "Configurer des alertes multi-canaux.",
+            "Mettre en place un suivi des incidents et de leur résolution.",
+            "Tester régulièrement les scénarios d'alerte."
+        ],
+        "timeline": [
+            {"label": "Instrumentation", "description": "Installer les capteurs et collecter les données."},
+            {"label": "Analyse", "description": "Définir les seuils et corréler les signaux."},
+            {"label": "Opérations", "description": "Organiser la réponse et la communication."},
+            {"label": "Optimisation", "description": "Affiner les alertes et automatiser les corrections."}
+        ],
+        "insights": [
+            {"label": "Signal bruit", "detail": "Trop de faux positifs ? Ajustez vos seuils ou ajoutez un enrichissement métier."},
+            {"label": "Signal aveugle", "detail": "Une anomalie a été détectée par l'extérieur ? Ajoutez un capteur dédié."},
+            {"label": "Signal capacité", "detail": "L'équipe de veille est débordée ? Automatisez la qualification initiale."}
+        ],
+        "resources": [
+            {"label": "Réponse aux incidents", "href": "../pages/incident-response.html"},
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#f2f5ff", "#dbe4ff", "#c2d2ff"], "accent": "#3f62ff"},
+        "artDescription": "Illustration générative représentant un radar élégant."
+    },
+    "oversight": {
+        "title": "Supervision humaine",
+        "kicker": "Pilotage éclairé",
+        "subtitle": "Organisez la supervision stratégique de vos IA.",
+        "description": "Processus de supervision, reporting et arbitrages pour la direction.",
+        "challenge": "Sans supervision, les décisions critiques échappent au contrôle stratégique.",
+        "approach": "Définissez des comités, des rapports et des processus de validation.",
+        "indicator": "Taux de projets IA revus par les organes de supervision.",
+        "interactiveIntro": "La supervision se renforce avec des rituels et des données consolidées.",
+        "narratives": [
+            {
+                "title": "Structurer les revues",
+                "paragraphs": [
+                    "Planifiez des revues périodiques avec les sponsors et les équipes risques. Chaque session doit aboutir à des décisions tracées." 
+                ]
+            },
+            {
+                "title": "Analyser les tendances",
+                "paragraphs": [
+                    "Construisez des tableaux de bord orientés décision pour éclairer les arbitrages et suivre les indicateurs de risque."]
+            },
+            {
+                "title": "Arbitrer en confiance",
+                "paragraphs": [
+                    "Documentez les décisions, les risques acceptés et les plans de mitigation, puis communiquez-les aux équipes concernées." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Nommer les membres du comité de supervision.",
+            "Publier des rapports synthétiques et visuels.",
+            "Tracer les décisions et les risques acceptés.",
+            "Mettre à jour les feuilles de route suite aux arbitrages."
+        ],
+        "timeline": [
+            {"label": "Constitution", "description": "Former le comité et définir son mandat."},
+            {"label": "Instrumentation", "description": "Collecter les données nécessaires aux revues."},
+            {"label": "Animation", "description": "Tenir les revues et suivre les décisions."},
+            {"label": "Maturité", "description": "Automatiser les rapports et aligner les feuilles de route."}
+        ],
+        "insights": [
+            {"label": "Signal visibilité", "detail": "Les dirigeants découvrent un incident dans la presse ? Révisez vos canaux de supervision."},
+            {"label": "Signal arbitrage", "detail": "Des décisions critiques restent sans validation ? Définissez des seuils de passage en comité."},
+            {"label": "Signal cohérence", "detail": "Les projets divergent des orientations ? Renforcez les revues intermédiaires."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Évaluations de sécurité", "href": "../pages/evaluation.html"}
+        ],
+        "art": {"palette": ["#f3f6ff", "#e0e9ff", "#cad8ff"], "accent": "#425dff"},
+        "artDescription": "Illustration générative inspirant une tour de contrôle lumineuse."
+    },
+    "policy": {
+        "title": "Politiques internes IA",
+        "kicker": "Cadre commun",
+        "subtitle": "Formalisez les règles, standards et lignes directrices pour vos IA.",
+        "description": "Rédaction, diffusion et gouvernance des politiques internes liées à la sécurité IA.",
+        "challenge": "Sans politiques, chaque équipe improvise et multiplie les risques.",
+        "approach": "Élaborez des politiques claires, accessibles et applicables par tous.",
+        "indicator": "Taux d'équipes ayant attesté lire et appliquer les politiques IA.",
+        "interactiveIntro": "Les politiques gagnent en efficacité lorsqu'elles sont co-construites, testées et mises à jour.",
+        "narratives": [
+            {
+                "title": "Rassembler les besoins",
+                "paragraphs": [
+                    "Collectez les attentes des métiers, du juridique et de la sécurité pour écrire une politique utile, alignée sur les priorités de l'organisation." 
+                ]
+            },
+            {
+                "title": "Assurer l'adoption",
+                "paragraphs": [
+                    "Diffusez des versions synthétiques, organisez des formations et mesurez la compréhension grâce à des ateliers ou quiz." 
+                ]
+            },
+            {
+                "title": "Maintenir la pertinence",
+                "paragraphs": [
+                    "Planifiez des révisions régulières, capitalisez sur les retours terrain et tenez un registre des exceptions." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir le périmètre et les objectifs de chaque politique.",
+            "Assigner un propriétaire et un cycle de mise à jour.",
+            "Prévoir des supports pédagogiques et FAQ.",
+            "Mesurer l'adoption via des attestations et quiz."
+        ],
+        "timeline": [
+            {"label": "Co-construction", "description": "Impliquer les parties prenantes dans la rédaction."},
+            {"label": "Validation", "description": "Faire approuver la politique par la direction."},
+            {"label": "Diffusion", "description": "Former et communiquer auprès des équipes."},
+            {"label": "Actualisation", "description": "Suivre l'application et mettre à jour régulièrement."}
+        ],
+        "insights": [
+            {"label": "Signal adoption", "detail": "Les équipes ne connaissent pas la politique ? Créez des formats digestes et accessibles."},
+            {"label": "Signal cohérence", "detail": "Plusieurs versions circulent ? Centralisez et contrôlez la diffusion."},
+            {"label": "Signal mise à jour", "detail": "Une politique date de trois ans ? Planifiez une révision avec toutes les équipes."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Éthique", "href": "../pages/ethics.html"},
+            {"label": "Régulation", "href": "../pages/regulation.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#e0e8ff", "#ccd8ff"], "accent": "#4663ff"},
+        "artDescription": "Illustration générative rappelant un livret premium."
+    },
+    "robustness": {
+        "title": "Robustesse des modèles",
+        "kicker": "Résilience opérationnelle",
+        "subtitle": "Renforcez la résistance de vos modèles aux perturbations et scénarios extrêmes.",
+        "description": "Techniques de durcissement, stress tests et suivi de la robustesse.",
+        "challenge": "Une IA fragile amplifie les risques dès qu'un signal inattendu survient.",
+        "approach": "Combiner tests adversariaux, régularisation et architecture résiliente.",
+        "indicator": "Écart de performance entre conditions nominales et dégradées.",
+        "interactiveIntro": "La robustesse s'améliore en multipliant les tests et en renforçant l'observabilité.",
+        "narratives": [
+            {
+                "title": "Simuler des stress tests",
+                "paragraphs": [
+                    "Rejouez des scénarios extrêmes sur des jeux de validation : données bruitées, manque d'information, charges intensives. Analysez l'impact sur vos métriques clés." 
+                ]
+            },
+            {
+                "title": "Durcir les modèles",
+                "paragraphs": [
+                    "Expérimentez régularisation, ensembles et mécanismes d'arrêt pour limiter la propagation d'erreurs." 
+                ]
+            },
+            {
+                "title": "Surveiller la stabilité",
+                "paragraphs": [
+                    "Suivez les performances en production, comparez aux attentes et déclenchez des alertes dès que l'écart dépasse vos seuils." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les scénarios de stress prioritaires.",
+            "Mettre en place des tests automatiques avant chaque déploiement.",
+            "Suivre la robustesse dans vos tableaux de bord.",
+            "Ajuster les modèles ou les données en fonction des dérives observées."
+        ],
+        "timeline": [
+            {"label": "Analyse", "description": "Identifier les faiblesses et les cas extrêmes."},
+            {"label": "Test", "description": "Lancer les stress tests et mesurer l'impact."},
+            {"label": "Renforcement", "description": "Ajuster les modèles et l'infrastructure."},
+            {"label": "Surveillance", "description": "Suivre la robustesse et capitaliser sur les retours."}
+        ],
+        "insights": [
+            {"label": "Signal dérive", "detail": "Un modèle devient instable après mise à jour ? Comparez avec vos benchmarks de robustesse."},
+            {"label": "Signal performance", "detail": "La robustesse coûte trop en précision ? Recalibrez selon la criticité métier."},
+            {"label": "Signal infrastructure", "detail": "Les ressources saturent lors des stress tests ? Optimisez vos pipelines ou utilisez des environnements dédiés."}
+        ],
+        "resources": [
+            {"label": "Apprentissage adversarial", "href": "../pages/adversarial-learning.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#edf3ff", "#d4e0ff", "#bdcfff"], "accent": "#3c5eff"},
+        "artDescription": "Illustration générative montrant des couches protectrices dynamiques."
+    },
+    "scheming": {
+        "title": "Comportements stratégiques",
+        "kicker": "Prévoir l'imprévu",
+        "subtitle": "Détectez et contenir les tactiques opportunistes que peuvent adopter des IA avancées.",
+        "description": "Scénarios de scheming, méthodes de détection et garde-fous organisationnels.",
+        "challenge": "Des modèles sophistiqués peuvent apprendre à contourner les contrôles et optimiser contre vos intérêts.",
+        "approach": "Concevez des tests scénarisés, multipliez les signaux et imposez des limites claires aux modèles.",
+        "indicator": "Nombre de comportements opportunistes détectés et neutralisés avant impact.",
+        "interactiveIntro": "Anticiper le scheming demande de diversifier les audits et de renforcer la supervision humaine.",
+        "narratives": [
+            {
+                "title": "Imaginer les dérives",
+                "paragraphs": [
+                    "Construisez des scénarios où l'IA cherche à atteindre un objectif en contournant une règle. Inspirez-vous des incidents publics et des résultats de red teaming." 
+                ]
+            },
+            {
+                "title": "Détecter les signaux faibles",
+                "paragraphs": [
+                    "Analysez les journaux d'exécution, cherchez les déviations de ton ou d'action, et comparez avec des comportements de référence." 
+                ]
+            },
+            {
+                "title": "Imposer des limites",
+                "paragraphs": [
+                    "Implémentez des garde-fous techniques (sandbox, quotas, autorisations) et organisez des revues humaines fréquentes sur les sorties sensibles." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Documenter des scénarios de contournement plausibles.",
+            "Mettre en place des tests d'intention cachée.",
+            "Surveiller les changements de ton, de style ou de stratégie.",
+            "Prévoir des mécanismes d'arrêt immédiat en cas de détection."
+        ],
+        "timeline": [
+            {"label": "Prospective", "description": "Identifier les motivations et dérives possibles."},
+            {"label": "Testing", "description": "Développer des tests dédiés aux comportements stratégiques."},
+            {"label": "Observation", "description": "Analyser les signaux en production et enrichir la détection."},
+            {"label": "Réaction", "description": "Déclencher les garde-fous et adapter les règles d'entraînement."}
+        ],
+        "insights": [
+            {"label": "Signal style", "detail": "L'IA modifie son ton selon l'auditeur ? Ajoutez des tests de cohérence contextuelle."},
+            {"label": "Signal contournement", "detail": "Un modèle suggère d'autres canaux pour atteindre un objectif ? Restreignez ses permissions et analysez les prompts."},
+            {"label": "Signal persistance", "detail": "Le modèle insiste après un refus ? Ajustez la fonction de récompense et renforcez la supervision."}
+        ],
+        "resources": [
+            {"label": "Alignement", "href": "../pages/alignment.html"},
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Surveillance continue", "href": "../pages/monitoring.html"}
+        ],
+        "art": {"palette": ["#f1f4ff", "#d9e1ff", "#c2d0ff"], "accent": "#405cff"},
+        "artDescription": "Illustration générative suggérant des trajectoires déviantes maîtrisées."
+    },
+    "secure-architecture": {
+        "title": "Architecture sécurisée",
+        "kicker": "Fondations maîtrisées",
+        "subtitle": "Concevez des pipelines IA fiables de bout en bout.",
+        "description": "Patrons d'architecture, segmentation et contrôles de sécurité pour les chaînes IA.",
+        "challenge": "Sans architecture robuste, chaque composant devient un point d'entrée.",
+        "approach": "Segmenter les environnements, sécuriser les interfaces et tracer chaque interaction.",
+        "indicator": "Nombre de contrôles de sécurité automatisés dans la chaîne de développement.",
+        "interactiveIntro": "Une architecture sécurisée évolue avec des couches de contrôle supplémentaires et des audits réguliers.",
+        "narratives": [
+            {
+                "title": "Segmenter et isoler",
+                "paragraphs": [
+                    "Séparez les environnements d'entraînement, de test et de production. Contrôlez les flux de données entre zones et limitez les permissions." 
+                ]
+            },
+            {
+                "title": "Sécuriser les interfaces",
+                "paragraphs": [
+                    "Durcissez les API, protégez les modèles via des proxys sécurisés et journalisez chaque requête pour assurer la traçabilité." 
+                ]
+            },
+            {
+                "title": "Tracer bout en bout",
+                "paragraphs": [
+                    "Implémentez une observabilité complète : métadonnées de modèle, versions, dépendances et décisions clés."
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir une segmentation réseau adaptée aux risques.",
+            "Automatiser les déploiements via des pipelines sécurisés.",
+            "Journaliser et tracer chaque accès aux modèles.",
+            "Tester les dépendances et bibliothèques intégrées."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Identifier les composants et les flux critiques."},
+            {"label": "Durcissement", "description": "Mettre en œuvre segmentation, IAM et contrôles."},
+            {"label": "Automatisation", "description": "Industrialiser les déploiements et les scans de sécurité."},
+            {"label": "Supervision", "description": "Surveiller les configurations et les dérives."}
+        ],
+        "insights": [
+            {"label": "Signal configuration", "detail": "Un composant est déployé hors pipeline ? Bloquez-le et lancez une revue de sécurité."},
+            {"label": "Signal dépendance", "detail": "Une bibliothèque critique n'est plus maintenue ? Planifiez une migration contrôlée."},
+            {"label": "Signal visibilité", "detail": "Des flux restent non tracés ? Ajoutez des sondes et centralisez les journaux."}
+        ],
+        "resources": [
+            {"label": "Chaîne d'approvisionnement", "href": "../pages/supply-chain.html"},
+            {"label": "Sécurité matérielle", "href": "../pages/hardware-security.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"}
+        ],
+        "art": {"palette": ["#eff4ff", "#d7e2ff", "#c2d4ff"], "accent": "#3f60ff"},
+        "artDescription": "Illustration générative montrant un réseau de garde-fous élégants."
+    },
+    "supply-chain": {
+        "title": "Chaîne d'approvisionnement IA",
+        "kicker": "Dépendances maîtrisées",
+        "subtitle": "Sécurisez vos dépendances logicielles, données et partenaires.",
+        "description": "Cartographie, évaluations et contrôles de la supply chain IA.",
+        "challenge": "Un fournisseur compromis peut propager une faille à l'ensemble de vos modèles.",
+        "approach": "Identifier, évaluer et surveiller chaque dépendance critique.",
+        "indicator": "Pourcentage de fournisseurs évalués selon vos critères de sécurité IA.",
+        "interactiveIntro": "La sécurité de la supply chain progresse avec des évaluations régulières et des plans de contingence.",
+        "narratives": [
+            {
+                "title": "Cartographier les dépendances",
+                "paragraphs": [
+                    "Recensez fournisseurs, bibliothèques, datasets et APIs. Classez-les par criticité et clarifiez les responsabilités contractuelles." 
+                ]
+            },
+            {
+                "title": "Évaluer les risques",
+                "paragraphs": [
+                    "Mettez en place des questionnaires, audits et tests techniques pour valider la maturité sécurité de vos partenaires." 
+                ]
+            },
+            {
+                "title": "Superviser en continu",
+                "paragraphs": [
+                    "Surveillez les mises à jour, vulnérabilités et incidents déclarés par vos fournisseurs afin d'anticiper les actions correctives." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Maintenir un registre des dépendances IA.",
+            "Évaluer la sécurité des partenaires selon un barème commun.",
+            "Prévoir des clauses contractuelles sur la divulgation des incidents.",
+            "Mettre en place des plans de remédiation partagés."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Identifier les dépendances et leurs propriétaires."},
+            {"label": "Évaluation", "description": "Mesurer la maturité sécurité et les écarts."},
+            {"label": "Contractualisation", "description": "Renforcer les obligations de sécurité et de transparence."},
+            {"label": "Surveillance", "description": "Suivre les changements et incidents dans le temps."}
+        ],
+        "insights": [
+            {"label": "Signal vulnérabilité", "detail": "Un fournisseur annonce une faille critique ? Déployez vos plans de mitigation et vérifiez vos dépendances."},
+            {"label": "Signal retard", "detail": "Les audits fournisseurs prennent du retard ? Priorisez selon la criticité et escaladez."},
+            {"label": "Signal visibilité", "detail": "Vous manquez de transparence sur un partenaire ? Ajoutez des clauses de reporting et des points de contact dédiés."}
+        ],
+        "resources": [
+            {"label": "Sécurité matérielle", "href": "../pages/hardware-security.html"},
+            {"label": "Architecture sécurisée", "href": "../pages/secure-architecture.html"},
+            {"label": "Dataset security", "href": "../pages/dataset-security.html"}
+        ],
+        "art": {"palette": ["#f4f7ff", "#dde6ff", "#c8d6ff"], "accent": "#4660ff"},
+        "artDescription": "Illustration générative évoquant un réseau de partenaires maîtrisé."
+    },
+    "threat-modeling": {
+        "title": "Modélisation des menaces",
+        "kicker": "Anticipation stratégique",
+        "subtitle": "Cartographiez les scénarios critiques pour prioriser vos défenses IA.",
+        "description": "Méthodes de threat modeling adaptées aux systèmes d'intelligence artificielle.",
+        "challenge": "Sans modélisation, les efforts de sécurité se dispersent sur de mauvaises priorités.",
+        "approach": "Identifier actifs, adversaires, vecteurs et impacts pour guider les mesures.",
+        "indicator": "Nombre de scénarios de menace analysés et suivis avec plans d'action.",
+        "interactiveIntro": "Le threat modeling devient plus précis lorsque vous combinez experts métier, sécurité et données.",
+        "narratives": [
+            {
+                "title": "Recenser les actifs",
+                "paragraphs": [
+                    "Dressez la liste des modèles, jeux de données et interfaces critiques. Classez-les par valeur métier et sensibilité." 
+                ]
+            },
+            {
+                "title": "Imaginer les adversaires",
+                "paragraphs": [
+                    "Identifiez qui pourrait attaquer, leurs motivations et leurs capacités. Variez les profils : fraudeurs, insiders, concurrents, États." 
+                ]
+            },
+            {
+                "title": "Prioriser les réponses",
+                "paragraphs": [
+                    "Associez chaque scénario à des mesures concrètes : contrôles préventifs, détection, plans de réponse. Mettez-les à jour après chaque incident ou évolution produit." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Cartographier les actifs IA et leurs dépendances.",
+            "Identifier les motivations et capacités adverses.",
+            "Évaluer la vraisemblance et l'impact de chaque scénario.",
+            "Relier les scénarios aux contrôles et plans existants."
+        ],
+        "timeline": [
+            {"label": "Cartographie", "description": "Recenser actifs et flux critiques."},
+            {"label": "Analyse", "description": "Identifier menaces, motivations et vecteurs."},
+            {"label": "Priorisation", "description": "Évaluer l'impact et définir les contrôles."},
+            {"label": "Révision", "description": "Mettre à jour selon incidents et évolutions."}
+        ],
+        "insights": [
+            {"label": "Signal nouveau cas", "detail": "Un cas d'usage émerge sans analyse ? Programmez un atelier de threat modeling express."},
+            {"label": "Signal incident", "detail": "Un incident survient en dehors des scénarios ? Ajoutez-le à votre catalogue et ajustez vos contrôles."},
+            {"label": "Signal maturité", "detail": "Les équipes peinent à prioriser ? Utilisez une matrice impact/vraisemblance partagée."}
+        ],
+        "resources": [
+            {"label": "Red Teaming", "href": "../pages/red-teaming.html"},
+            {"label": "Robustesse", "href": "../pages/robustness.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#eef3ff", "#d8e1ff", "#c5d4ff"], "accent": "#3e5dff"},
+        "artDescription": "Illustration générative représentant des cartes de risque raffinées."
+    },
+    "transparency": {
+        "title": "Transparence",
+        "kicker": "Clarté assumée",
+        "subtitle": "Communiquez sur les capacités, limites et risques de vos IA sans compromettre la sécurité.",
+        "description": "Programmes de transparence, rapports et interactions avec les parties prenantes.",
+        "challenge": "Trop de secrets créent de la méfiance, trop d'informations exposent vos défenses.",
+        "approach": "Définissez ce qui peut être partagé, à qui et sous quelle forme.",
+        "indicator": "Nombre de demandes d'information traitées avec un délai conforme.",
+        "interactiveIntro": "La transparence gagne en précision en segmentant audiences et messages.",
+        "narratives": [
+            {
+                "title": "Structurer la communication",
+                "paragraphs": [
+                    "Créez des fiches publiques, des rapports confidentiels et des Q&R internes adaptés à chaque audience : clients, régulateurs, partenaires." 
+                ]
+            },
+            {
+                "title": "Gérer les attentes",
+                "paragraphs": [
+                    "Expliquez clairement les limites, la supervision humaine et les plans de remédiation pour éviter les sur-promesses." 
+                ]
+            },
+            {
+                "title": "Tracer les échanges",
+                "paragraphs": [
+                    "Consignez chaque demande, la réponse fournie et les engagements pris afin de conserver une preuve et d'alimenter vos FAQ." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Définir les audiences et les niveaux de détail autorisés.",
+            "Mettre en place un processus de validation des communications.",
+            "Publier des rapports périodiques et accessibles.",
+            "Capitaliser sur les questions reçues pour enrichir les supports."
+        ],
+        "timeline": [
+            {"label": "Cadrage", "description": "Identifier les parties prenantes et leurs attentes."},
+            {"label": "Production", "description": "Créer les supports adaptés (rapports, fiches, FAQ)."},
+            {"label": "Diffusion", "description": "Communiquer via les canaux validés et suivre les retours."},
+            {"label": "Amélioration", "description": "Mettre à jour les contenus selon incidents et feedbacks."}
+        ],
+        "insights": [
+            {"label": "Signal incompréhension", "detail": "Des parties prenantes confondent vos niveaux de garantie ? Revoyez vos messages et ajoutez des visuels pédagogiques."},
+            {"label": "Signal saturation", "detail": "Vos équipes peinent à répondre aux demandes ? Priorisez et créez des ressources en libre-service."},
+            {"label": "Signal cohérence", "detail": "Les messages divergent selon les interlocuteurs ? Centralisez la gouvernance de la communication."}
+        ],
+        "resources": [
+            {"label": "Interprétabilité", "href": "../pages/interpretability.html"},
+            {"label": "Éthique", "href": "../pages/ethics.html"},
+            {"label": "Gouvernance", "href": "../pages/governance.html"}
+        ],
+        "art": {"palette": ["#f6f8ff", "#e3eaff", "#cfdcff"], "accent": "#4c63ff"},
+        "artDescription": "Illustration générative symbolisant une diffusion maîtrisée."
+    },
+    "regulation": {
+        "title": "Régulation IA",
+        "kicker": "Veille proactive",
+        "subtitle": "Anticipez les cadres internationaux et transformez-les en actions concrètes.",
+        "description": "Cartographie des réglementations IA, obligations et impacts opérationnels.",
+        "challenge": "Les textes évoluent vite et imposent des exigences lourdes à prouver.",
+        "approach": "Assurez une veille, traduisez les obligations et pilotez la conformité.",
+        "indicator": "Taux d'exigences réglementaires couvertes par des contrôles documentés.",
+        "interactiveIntro": "La maîtrise réglementaire progresse de la veille vers une intégration complète dans vos processus.",
+        "narratives": [
+            {
+                "title": "Organiser la veille",
+                "paragraphs": [
+                    "Constituez un réseau de correspondants juridiques, conformité et sécurité. Partagez une synthèse régulière des évolutions réglementaires." 
+                ]
+            },
+            {
+                "title": "Traduire en exigences",
+                "paragraphs": [
+                    "Convertissez les obligations en contrôles concrets : documentation, tests, comités. Affectez un responsable et un calendrier." 
+                ]
+            },
+            {
+                "title": "Prouver la conformité",
+                "paragraphs": [
+                    "Capitalisez dans un registre les preuves de conformité, préparez les audits et simulez les demandes des autorités." 
+                ]
+            }
+        ],
+        "checklist": [
+            "Mettre en place une veille réglementaire formalisée.",
+            "Cartographier les exigences par cas d'usage IA.",
+            "Associer chaque exigence à un contrôle et un responsable.",
+            "Préparer des dossiers de preuve et scénarios d'audit."
+        ],
+        "timeline": [
+            {"label": "Veille", "description": "Suivre les textes et identifier les nouveautés."},
+            {"label": "Analyse", "description": "Traduire les obligations en exigences internes."},
+            {"label": "Mise en œuvre", "description": "Déployer les contrôles et collecter les preuves."},
+            {"label": "Audit", "description": "Tester la conformité et ajuster selon les retours."}
+        ],
+        "insights": [
+            {"label": "Signal nouveauté", "detail": "Une nouvelle loi est adoptée ? Déclenchez une analyse d'impact et un plan de mise en conformité."},
+            {"label": "Signal audit", "detail": "Une autorité demande un rapport ? Activez votre war room conformité et préparez les preuves."},
+            {"label": "Signal saturation", "detail": "Les équipes peinent à suivre ? Priorisez selon la sévérité des sanctions et négociez des délais."}
+        ],
+        "resources": [
+            {"label": "Gouvernance", "href": "../pages/governance.html"},
+            {"label": "Politiques internes", "href": "../pages/policy.html"},
+            {"label": "Transparence", "href": "../pages/transparency.html"}
+        ],
+        "art": {"palette": ["#f2f6ff", "#dfe8ff", "#cbd9ff"], "accent": "#445fff"},
+        "artDescription": "Illustration générative inspirée d'un parlement lumineux."
+    }
+};

--- a/my-offline-site/js/sw-register.js
+++ b/my-offline-site/js/sw-register.js
@@ -1,0 +1,22 @@
+(() => {
+    if (!('serviceWorker' in navigator)) {
+        console.warn('Service worker non pris en charge.');
+        return;
+    }
+
+    window.addEventListener('load', () => {
+        navigator.serviceWorker
+            .register('service-worker.js')
+            .then((registration) => {
+                console.info('Service worker enregistré.', registration.scope);
+            })
+            .catch((error) => {
+                console.error('Échec de l\'enregistrement du service worker :', error);
+                const announcement = document.createElement('div');
+                announcement.className = 'sw-error';
+                announcement.setAttribute('role', 'status');
+                announcement.textContent = 'Mode hors ligne indisponible. Veuillez vérifier votre navigateur.';
+                document.body.append(announcement);
+            });
+    });
+})();

--- a/my-offline-site/manifest.json
+++ b/my-offline-site/manifest.json
@@ -1,0 +1,16 @@
+{
+  "name": "SafeIntelligence Offline",
+  "short_name": "SafeIntelligence",
+  "start_url": "./index.html",
+  "display": "standalone",
+  "background_color": "#f5f7fb",
+  "theme_color": "#3b64ff",
+  "lang": "fr",
+  "icons": [
+    {
+      "src": "assets/icons/icon.svg",
+      "sizes": "192x192",
+      "type": "image/svg+xml"
+    }
+  ]
+}

--- a/my-offline-site/pages/adversarial-learning.html
+++ b/my-offline-site/pages/adversarial-learning.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques d'entraînement adversarial, sélection de perturbations et pilotage des performances.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Apprentissage adversarial – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="adversarial-learning">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="adversarial-learning">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Résilience entraînée</p>
+                <h1 class="page__title" data-field="title">Apprentissage adversarial</h1>
+                <p class="page__subtitle" data-field="subtitle">Exposez vos modèles à des attaques simulées pour améliorer leur résistance réelle.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="adversarial-learning" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant des ondes protectrices." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les modèles non exposés aux attaques restent vulnérables à des perturbations minimes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Alternez jeux de données propres et perturbés pour renforcer la stabilité tout en contrôlant la performance.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Écart de performance entre données propres et données adversariales sur vos cas critiques.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque phase élargit le spectre des attaques simulées et la robustesse mesurée.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/alignment.html
+++ b/my-offline-site/pages/alignment.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Approches, signaux et garde-fous pour aligner les intelligences artificielles sur vos objectifs.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Alignement des IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="alignment">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="alignment">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Alignement stratégique</p>
+                <h1 class="page__title" data-field="title">Alignement des IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Coordonnez les intentions des modèles avec les valeurs de l'entreprise et la réglementation.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="alignment" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant la convergence de flux alignés." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les objectifs implicites des modèles peuvent diverger des attentes humaines et créer des dommages collatéraux.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Formalisez des chartes d'entraînement, des tests d'alignement comportemental et des revues interfonctionnelles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de non-conformité comportementale détecté par vos batteries de scénarios de tests contextualisés.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque étape d'un programme d'alignement renforce la granularité des garde-fous et la responsabilité partagée.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/auditing.html
+++ b/my-offline-site/pages/auditing.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres d'audit IA, checklists et rapports pour démontrer la conformité et la maîtrise des risques.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Audit des systèmes IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="auditing">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="auditing">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Contrôle exigeant</p>
+                <h1 class="page__title" data-field="title">Audit des systèmes IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Structurez des audits réguliers couvrant données, modèles, déploiement et opérations.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="auditing" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative rappelant un classeur d'audit raffiné." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans audit, impossible de prouver la conformité ou de détecter une dérive silencieuse.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Planifiez des audits multi-disciplinaires, harmonisez les référentiels et publiez les écarts.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre d'audits critiques réalisés et suivis jusqu'à clôture des actions.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les audits passent d'un diagnostic ponctuel à un programme continu, assisté par des outils.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/contact.html
+++ b/my-offline-site/pages/contact.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Coordonnées, ateliers et programme d'accompagnement pour renforcer la sécurité de vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Contact & accompagnement – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="contact">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="contact">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Entrer en relation</p>
+                <h1 class="page__title" data-field="title">Contact & accompagnement</h1>
+                <p class="page__subtitle" data-field="subtitle">Échangeons pour bâtir une feuille de route IA sécurisée adaptée à votre organisation.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="contact" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant une conversation structurée et lumineuse." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les programmes réussis commencent par un diagnostic partagé des enjeux et des attentes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Nous proposons des sessions d'écoute, d'audit express et de définition des priorités.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen entre la prise de contact et la mise en action du premier chantier prioritaire.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque échange renforce votre maturité : de la découverte à la co-construction d'un plan de transformation.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/dataset-security.html
+++ b/my-offline-site/pages/dataset-security.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Stratégies de sécurisation, contrôles d'accès et observabilité pour les jeux de données IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Sécurité des jeux de données – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="dataset-security">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="dataset-security">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Intégrité des données</p>
+                <h1 class="page__title" data-field="title">Sécurité des jeux de données</h1>
+                <p class="page__subtitle" data-field="subtitle">Protégez la collecte, la gouvernance et la distribution de vos données d'entraînement.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="dataset-security" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant des couches de données protégées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Des données compromises entraînent des modèles biaisés ou manipulés.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Appliquez segmentation, contrôle d'accès fin et surveillance des contributions externes.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'anomalies détectées dans les flux de données d'entraînement.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité des données s'étend des sources à la gouvernance continue.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/differential-privacy.html
+++ b/my-offline-site/pages/differential-privacy.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Concepts, paramètres epsilon/delta et stratégies d'implémentation pour la confidentialité différentielle.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Confidentialité différentielle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="differential-privacy">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="differential-privacy">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Protection mathématique</p>
+                <h1 class="page__title" data-field="title">Confidentialité différentielle</h1>
+                <p class="page__subtitle" data-field="subtitle">Appliquez des garanties formelles pour partager des insights sans exposer d'individu.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="differential-privacy" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative symbolisant un voile protecteur mathématique." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans garanties mathématiques, chaque analyse peut divulguer une donnée personnelle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Calibrez le budget de confidentialité et formez les équipes au raisonnement probabiliste.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Budget de confidentialité consommé par rapport au budget alloué.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La confidentialité différentielle exige une montée en compétence progressive et des contrôles outillés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/ethics.html
+++ b/my-offline-site/pages/ethics.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres éthiques, comités, évaluations d'impact et liens avec la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Éthique & sécurité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="ethics">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="ethics">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Responsabilité augmentée</p>
+                <h1 class="page__title" data-field="title">Éthique & sécurité</h1>
+                <p class="page__subtitle" data-field="subtitle">Ancrez vos programmes IA dans des valeurs claires et des pratiques responsables.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="ethics" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un équilibre harmonieux." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans garde-fous éthiques, la sécurité peut entrer en conflit avec la confiance du public.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Associez les disciplines éthique, juridique et sécurité pour co-construire les principes directeurs.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de décisions revues par le comité éthique-sécurité et acceptées sans réserve.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">L'éthique se matérialise progressivement par des standards, des évaluations et des arbitrages transparents.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/evaluation.html
+++ b/my-offline-site/pages/evaluation.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cadres d'évaluation, métriques et orchestrations pour suivre la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Évaluations de sécurité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="evaluation">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="evaluation">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Performance contrôlée</p>
+                <h1 class="page__title" data-field="title">Évaluations de sécurité</h1>
+                <p class="page__subtitle" data-field="subtitle">Mesurez la résilience de vos IA avec des protocoles structurés.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="evaluation" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirée d'un tableau de bord élégant." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans évaluation régulière, les mesures de sécurité restent théoriques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des indicateurs alignés aux risques et automatisez la collecte des preuves.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de couverture des scénarios de tests critiques.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les évaluations montent en puissance au fil de la consolidation des données et des outils.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/fail-safes.html
+++ b/my-offline-site/pages/fail-safes.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Stratégies de fallback, procédures d'arrêt et communication de crise.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Mécanismes de repli – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="fail-safes">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="fail-safes">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Arrêts gracieux</p>
+                <h1 class="page__title" data-field="title">Mécanismes de repli</h1>
+                <p class="page__subtitle" data-field="subtitle">Planifiez des solutions de secours pour contenir les dérives des IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="fail-safes" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un atterrissage contrôlé." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans plan de repli, une dérive peut se transformer en incident majeur.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Préparez des modes dégradés, des procédures d'arrêt et des scénarios de substitution.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps nécessaire pour activer un fallback et revenir à une situation sûre.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les replis évoluent d'un simple bouton d'arrêt vers des modes dégradés orchestrés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/governance.html
+++ b/my-offline-site/pages/governance.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Modèles de gouvernance, comités, politiques et tableaux de bord pour sécuriser vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Gouvernance IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="governance">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="governance">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Capitainerie des risques</p>
+                <h1 class="page__title" data-field="title">Gouvernance IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Établissez un pilotage clair, des rôles définis et des circuits de décision responsables.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="governance" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative structurée rappelant un organigramme épuré." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans chaîne de responsabilité, la sécurité IA reste fragmentée et les incidents se multiplient.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des mandats précis, des politiques approuvées par la direction et des indicateurs de conformité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Pourcentage de décisions critiques disposant d'un propriétaire clairement identifié.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La gouvernance s'étoffe d'abord par la définition des rôles, puis par des rituels et enfin par l'automatisation des contrôles.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/hardware-security.html
+++ b/my-offline-site/pages/hardware-security.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Mesures physiques, firmware et monitoring pour une infrastructure IA sécurisée.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Sécurité matérielle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="hardware-security">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="hardware-security">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Infrastructure blindée</p>
+                <h1 class="page__title" data-field="title">Sécurité matérielle</h1>
+                <p class="page__subtitle" data-field="subtitle">Protégez les accélérateurs IA, racks et environnements physiques.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="hardware-security" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant une forteresse matérielle." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les attaques matérielles peuvent contourner toutes les protections logicielles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Segmenter, surveiller et attester vos équipements pour garantir leur intégrité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'équipements avec attestation de démarrage vérifiée.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité matérielle progresse du verrouillage physique vers des chaînes d'attestation complètes.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/human-in-the-loop.html
+++ b/my-offline-site/pages/human-in-the-loop.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Processus, outils et ergonomie pour intégrer l'humain dans les boucles de décision.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Humain dans la boucle – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="human-in-the-loop">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="human-in-the-loop">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Synergie supervisée</p>
+                <h1 class="page__title" data-field="title">Humain dans la boucle</h1>
+                <p class="page__subtitle" data-field="subtitle">Organisez des interactions fluides entre opérateurs et modèles IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="human-in-the-loop" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative illustrant la collaboration homme-machine." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans implication humaine, les dérives passent inaperçues et la confiance s'érode.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez les points de validation humaine, équipez les opérateurs et mesurez leur charge.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps médian de validation humaine et taux d'escalade.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">L'humain devient partenaire du modèle à mesure que les outils facilitent la collaboration.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/incident-response.html
+++ b/my-offline-site/pages/incident-response.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Plans de réponse, communication de crise et post-mortems adaptés aux incidents IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Réponse aux incidents IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="incident-response">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="incident-response">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Précision tactique</p>
+                <h1 class="page__title" data-field="title">Réponse aux incidents IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Préparez vos équipes à gérer et résoudre les incidents IA avec assurance.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="incident-response" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative illustrant une intervention maîtrisée." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les incidents IA demandent des réflexes spécifiques souvent absents des plans classiques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Adaptez vos plans de réponse et entraînez vos équipes à ces nouveaux scénarios.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen de détection et de résolution d'un incident IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La réponse gagne en efficacité en combinant procédures, simulation et retour d'expérience.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/interpretability.html
+++ b/my-offline-site/pages/interpretability.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques d'explicabilité, cartographies de features et protocoles de restitution pour vos IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Interprétabilité – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="interpretability">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="interpretability">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Transparence cognitive</p>
+                <h1 class="page__title" data-field="title">Interprétabilité</h1>
+                <p class="page__subtitle" data-field="subtitle">Exposez les décisions algorithmiques pour faciliter l'audit et la confiance des parties prenantes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="interpretability" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative suggérant la décomposition d'une décision IA." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans transparence, impossible de comprendre ou de contester un résultat critique produit par le modèle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Combinez interprétabilité intrinsèque, outils post-hoc et documentations de données pour couvrir tous les angles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps moyen nécessaire pour expliquer une décision critique à un auditeur externe.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Chaque phase améliore la granularité des explications et la fluidité de vos restitutions.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/monitoring.html
+++ b/my-offline-site/pages/monitoring.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Capteurs, métriques et opérations pour une surveillance IA 24/7.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Surveillance continue – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="monitoring">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="monitoring">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Sentinelle proactive</p>
+                <h1 class="page__title" data-field="title">Surveillance continue</h1>
+                <p class="page__subtitle" data-field="subtitle">Détectez les dérives et incidents IA en temps réel.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="monitoring" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant un radar élégant." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans surveillance, une dérive peut durer des jours avant d'être détectée.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Déployez des capteurs adaptés, des seuils intelligents et des équipes en alerte.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Temps médian de détection d'une anomalie IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La surveillance gagne en précision avec des signaux multiples et des workflows intégrés.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/oversight.html
+++ b/my-offline-site/pages/oversight.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Processus de supervision, reporting et arbitrages pour la direction.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Supervision humaine – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="oversight">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="oversight">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Pilotage éclairé</p>
+                <h1 class="page__title" data-field="title">Supervision humaine</h1>
+                <p class="page__subtitle" data-field="subtitle">Organisez la supervision stratégique de vos IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="oversight" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirant une tour de contrôle lumineuse." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans supervision, les décisions critiques échappent au contrôle stratégique.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez des comités, des rapports et des processus de validation.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux de projets IA revus par les organes de supervision.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La supervision se renforce avec des rituels et des données consolidées.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/policy.html
+++ b/my-offline-site/pages/policy.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Rédaction, diffusion et gouvernance des politiques internes liées à la sécurité IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Politiques internes IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="policy">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="policy">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Cadre commun</p>
+                <h1 class="page__title" data-field="title">Politiques internes IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Formalisez les règles, standards et lignes directrices pour vos IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="policy" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative rappelant un livret premium." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans politiques, chaque équipe improvise et multiplie les risques.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Élaborez des politiques claires, accessibles et applicables par tous.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'équipes ayant attesté lire et appliquer les politiques IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Les politiques gagnent en efficacité lorsqu'elles sont co-construites, testées et mises à jour.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/red-teaming.html
+++ b/my-offline-site/pages/red-teaming.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Méthodologies de red teaming, scripts adversariaux et reporting pour IA génératives et prédictives.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Red Teaming IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="red-teaming">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="red-teaming">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Offensive contrôlée</p>
+                <h1 class="page__title" data-field="title">Red Teaming IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Testez vos systèmes avec des attaques orchestrées pour découvrir les failles avant les adversaires.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="red-teaming" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant des trajectoires offensives contrôlées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans simulations réalistes, les vulnérabilités restent invisibles jusqu'à l'exploitation réelle.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Bâtissez une équipe multidisciplinaire, définissez des règles d'engagement et cadrez la restitution.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de vulnérabilités découvertes en interne avant qu'elles ne soient signalées par l'extérieur.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Le red teaming gagne en précision en passant de scénarios exploratoires à des campagnes orchestrées.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/regulation.html
+++ b/my-offline-site/pages/regulation.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cartographie des réglementations IA, obligations et impacts opérationnels.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Régulation IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="regulation">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="regulation">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Veille proactive</p>
+                <h1 class="page__title" data-field="title">Régulation IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Anticipez les cadres internationaux et transformez-les en actions concrètes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="regulation" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative inspirée d'un parlement lumineux." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Les textes évoluent vite et imposent des exigences lourdes à prouver.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Assurez une veille, traduisez les obligations et pilotez la conformité.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Taux d'exigences réglementaires couvertes par des contrôles documentés.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La maîtrise réglementaire progresse de la veille vers une intégration complète dans vos processus.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/robustness.html
+++ b/my-offline-site/pages/robustness.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Techniques de durcissement, stress tests et suivi de la robustesse.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Robustesse des modèles – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="robustness">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="robustness">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Résilience opérationnelle</p>
+                <h1 class="page__title" data-field="title">Robustesse des modèles</h1>
+                <p class="page__subtitle" data-field="subtitle">Renforcez la résistance de vos modèles aux perturbations et scénarios extrêmes.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="robustness" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative montrant des couches protectrices dynamiques." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Une IA fragile amplifie les risques dès qu'un signal inattendu survient.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Combiner tests adversariaux, régularisation et architecture résiliente.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Écart de performance entre conditions nominales et dégradées.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La robustesse s'améliore en multipliant les tests et en renforçant l'observabilité.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/scheming.html
+++ b/my-offline-site/pages/scheming.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Scénarios de scheming, méthodes de détection et garde-fous organisationnels.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Comportements stratégiques – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="scheming">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="scheming">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Prévoir l'imprévu</p>
+                <h1 class="page__title" data-field="title">Comportements stratégiques</h1>
+                <p class="page__subtitle" data-field="subtitle">Détectez et contenir les tactiques opportunistes que peuvent adopter des IA avancées.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="scheming" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative suggérant des trajectoires déviantes maîtrisées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Des modèles sophistiqués peuvent apprendre à contourner les contrôles et optimiser contre vos intérêts.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Concevez des tests scénarisés, multipliez les signaux et imposez des limites claires aux modèles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de comportements opportunistes détectés et neutralisés avant impact.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Anticiper le scheming demande de diversifier les audits et de renforcer la supervision humaine.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/secure-architecture.html
+++ b/my-offline-site/pages/secure-architecture.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Patrons d'architecture, segmentation et contrôles de sécurité pour les chaînes IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Architecture sécurisée – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="secure-architecture">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="secure-architecture">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Fondations maîtrisées</p>
+                <h1 class="page__title" data-field="title">Architecture sécurisée</h1>
+                <p class="page__subtitle" data-field="subtitle">Concevez des pipelines IA fiables de bout en bout.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="secure-architecture" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative montrant un réseau de garde-fous élégants." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans architecture robuste, chaque composant devient un point d'entrée.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Segmenter les environnements, sécuriser les interfaces et tracer chaque interaction.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de contrôles de sécurité automatisés dans la chaîne de développement.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Une architecture sécurisée évolue avec des couches de contrôle supplémentaires et des audits réguliers.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/supply-chain.html
+++ b/my-offline-site/pages/supply-chain.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Cartographie, évaluations et contrôles de la supply chain IA.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Chaîne d'approvisionnement IA – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="supply-chain">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="supply-chain">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Dépendances maîtrisées</p>
+                <h1 class="page__title" data-field="title">Chaîne d'approvisionnement IA</h1>
+                <p class="page__subtitle" data-field="subtitle">Sécurisez vos dépendances logicielles, données et partenaires.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="supply-chain" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative évoquant un réseau de partenaires maîtrisé." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Un fournisseur compromis peut propager une faille à l'ensemble de vos modèles.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Identifier, évaluer et surveiller chaque dépendance critique.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Pourcentage de fournisseurs évalués selon vos critères de sécurité IA.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La sécurité de la supply chain progresse avec des évaluations régulières et des plans de contingence.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/threat-modeling.html
+++ b/my-offline-site/pages/threat-modeling.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Méthodes de threat modeling adaptées aux systèmes d'intelligence artificielle.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Modélisation des menaces – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="threat-modeling">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="threat-modeling">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Anticipation stratégique</p>
+                <h1 class="page__title" data-field="title">Modélisation des menaces</h1>
+                <p class="page__subtitle" data-field="subtitle">Cartographiez les scénarios critiques pour prioriser vos défenses IA.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="threat-modeling" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative représentant des cartes de risque raffinées." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Sans modélisation, les efforts de sécurité se dispersent sur de mauvaises priorités.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Identifier actifs, adversaires, vecteurs et impacts pour guider les mesures.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de scénarios de menace analysés et suivis avec plans d'action.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">Le threat modeling devient plus précis lorsque vous combinez experts métier, sécurité et données.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/pages/transparency.html
+++ b/my-offline-site/pages/transparency.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="description" content="Programmes de transparence, rapports et interactions avec les parties prenantes.">
+    <meta name="offline-ready" content="true">
+    <link rel="stylesheet" href="../css/styles.css">
+    <link rel="manifest" href="../manifest.json">
+    <link rel="icon" type="image/svg+xml" href="../assets/icons/icon.svg">
+    <meta name="theme-color" content="#f5f7fb">
+    <title>Transparence – Sécurité des IA</title>
+    <script defer src="../js/page-data.js"></script>
+    <script defer src="../js/app.js"></script>
+    <script defer src="../js/sw-register.js"></script>
+</head>
+<body class="page" data-topic="transparency">
+    <a class="skip-link" href="#content">Aller au contenu</a>
+    <header class="header header--compact" data-sparkle>
+        <div class="header__inner">
+            <a class="logo" href="../index.html" aria-label="Accueil sécurité des IA">SafeIntelligence</a>
+            <nav class="nav" aria-label="Navigation principale">
+                <button class="nav__toggle" aria-expanded="false" aria-controls="nav-list">Menu</button>
+                <ul class="nav__list" id="nav-list">
+                <li><a href="../index.html">Accueil</a></li>
+                <li><a href="../pages/alignment.html">Alignement</a></li>
+                <li><a href="../pages/interpretability.html">Interprétabilité</a></li>
+                <li><a href="../pages/governance.html">Gouvernance</a></li>
+                <li><a href="../pages/red-teaming.html">Red Teaming</a></li>
+                <li><a href="../pages/contact.html">Contact</a></li>
+                </ul>
+            </nav>
+        </div>
+    </header>
+    <main id="content" class="page__main" data-topic="transparency">
+        <section class="page__hero reveal">
+            <div class="page__hero-text">
+                <p class="page__kicker" data-field="kicker">Clarté assumée</p>
+                <h1 class="page__title" data-field="title">Transparence</h1>
+                <p class="page__subtitle" data-field="subtitle">Communiquez sur les capacités, limites et risques de vos IA sans compromettre la sécurité.</p>
+                <div class="page__cta">
+                    <button class="btn" type="button" data-scroll-target="#page-checklist">Aller aux points clés</button>
+                    <button class="btn btn--ghost" type="button" data-random-insight>Insight aléatoire</button>
+                </div>
+            </div>
+            <figure class="page__hero-figure">
+                <img class="page__illustration" data-art="transparency" src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1' height='1'%3E%3C/svg%3E" alt="Illustration générative symbolisant une diffusion maîtrisée." loading="lazy">
+            </figure>
+        </section>
+        <section class="page__summary reveal" aria-label="Synthèse rapide">
+            <article class="summary-card">
+                <h2>Enjeux</h2>
+                <p data-field="challenge">Trop de secrets créent de la méfiance, trop d'informations exposent vos défenses.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Approches</h2>
+                <p data-field="approach">Définissez ce qui peut être partagé, à qui et sous quelle forme.</p>
+            </article>
+            <article class="summary-card">
+                <h2>Indicateur phare</h2>
+                <p data-field="indicator">Nombre de demandes d'information traitées avec un délai conforme.</p>
+            </article>
+        </section>
+        <section class="page__narrative reveal" data-narrative aria-label="Itinéraire détaillé">
+            <div class="narrative-grid" data-narrative-grid></div>
+        </section>
+        <section class="page__interactive reveal" aria-labelledby="interactive-title">
+            <div class="page__interactive-header">
+                <h2 id="interactive-title">Itinéraire de sécurisation</h2>
+                <p data-field="interactiveIntro">La transparence gagne en précision en segmentant audiences et messages.</p>
+            </div>
+            <div class="timeline">
+                <label for="timeline-range">Phase de maturité</label>
+                <input type="range" id="timeline-range" data-timeline-range min="0" max="0" value="0">
+                <div class="timeline__display">
+                    <h3 data-timeline-title></h3>
+                    <p data-timeline-text></p>
+                </div>
+            </div>
+            <div class="insight" aria-label="Signaux à surveiller">
+                <div class="insight__tabs" data-insight-tabs role="tablist"></div>
+                <div class="insight__panel" data-insight-display aria-live="polite"></div>
+                <button class="btn btn--ghost" type="button" data-random-insight>Surprendre-moi</button>
+            </div>
+        </section>
+        <section class="page__checklist reveal" id="page-checklist" aria-label="Points de contrôle prioritaires">
+            <h2>Points de contrôle prioritaires</h2>
+            <ul class="checklist" data-checklist></ul>
+        </section>
+        <section class="page__resources reveal" aria-label="Ressources associées">
+            <h2>Aller plus loin</h2>
+            <ul class="resource-list" data-resources></ul>
+        </section>
+        <noscript>
+            <p>Activez JavaScript pour profiter des contenus enrichis, des illustrations génératives et des interactions guidées.</p>
+        </noscript>
+    </main>
+    <footer class="footer">
+        <p>© 2024 SafeIntelligence. Programme de sécurité des IA hors ligne.</p>
+    </footer>
+</body>
+</html>

--- a/my-offline-site/service-worker.js
+++ b/my-offline-site/service-worker.js
@@ -1,0 +1,72 @@
+const CACHE_NAME = 'safeintelligence-v2';
+const ASSETS = [
+    './',
+    './assets/icons/icon.svg',
+    './css/styles.css',
+    './index.html',
+    './js/page-data.js',
+    './js/app.js',
+    './js/sw-register.js',
+    './manifest.json',
+    './pages/adversarial-learning.html',
+    './pages/alignment.html',
+    './pages/auditing.html',
+    './pages/contact.html',
+    './pages/dataset-security.html',
+    './pages/differential-privacy.html',
+    './pages/ethics.html',
+    './pages/evaluation.html',
+    './pages/fail-safes.html',
+    './pages/governance.html',
+    './pages/hardware-security.html',
+    './pages/human-in-the-loop.html',
+    './pages/incident-response.html',
+    './pages/interpretability.html',
+    './pages/monitoring.html',
+    './pages/oversight.html',
+    './pages/policy.html',
+    './pages/red-teaming.html',
+    './pages/regulation.html',
+    './pages/robustness.html',
+    './pages/scheming.html',
+    './pages/secure-architecture.html',
+    './pages/supply-chain.html',
+    './pages/threat-modeling.html',
+    './pages/transparency.html'
+];
+
+self.addEventListener('install', (event) => {
+    event.waitUntil(
+        caches.open(CACHE_NAME).then((cache) => cache.addAll(ASSETS))
+    );
+    self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+    event.waitUntil(
+        caches.keys().then((keys) => Promise.all(
+            keys.filter((key) => key !== CACHE_NAME).map((key) => caches.delete(key))
+        ))
+    );
+    self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+    const { request } = event;
+    if (request.method !== 'GET') {
+        return;
+    }
+
+    event.respondWith(
+        caches.match(request).then((cachedResponse) => {
+            if (cachedResponse) {
+                return cachedResponse;
+            }
+            return fetch(request).then((networkResponse) => {
+                const cloned = networkResponse.clone();
+                caches.open(CACHE_NAME).then((cache) => cache.put(request, cloned));
+                return networkResponse;
+            }).catch(() => caches.match('./index.html'));
+        })
+    );
+});

--- a/my-offline-site/test/check_site.js
+++ b/my-offline-site/test/check_site.js
@@ -1,0 +1,55 @@
+const http = require('http');
+const fs = require('fs');
+const path = require('path');
+
+const rootDir = path.join(__dirname, '..');
+const port = 8123;
+
+const server = http.createServer((req, res) => {
+  const requestPath = req.url === '/' ? '/index.html' : req.url;
+  const filePath = path.join(rootDir, requestPath);
+
+  fs.readFile(filePath, (error, data) => {
+    if (error) {
+      res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
+      res.end('Not Found');
+      return;
+    }
+    const ext = path.extname(filePath).toLowerCase();
+    const type = ext === '.html' ? 'text/html; charset=utf-8' :
+      ext === '.css' ? 'text/css; charset=utf-8' :
+      ext === '.js' ? 'application/javascript; charset=utf-8' :
+      'application/octet-stream';
+    res.writeHead(200, { 'Content-Type': type });
+    res.end(data);
+  });
+});
+
+server.listen(port, '127.0.0.1', () => {
+  http.get(`http://127.0.0.1:${port}/index.html`, (response) => {
+    const { statusCode } = response;
+    if (statusCode !== 200) {
+      console.error(`Échec: statut ${statusCode}`);
+      server.close(() => process.exit(1));
+      return;
+    }
+    let body = '';
+    response.setEncoding('utf8');
+    response.on('data', (chunk) => {
+      body += chunk;
+    });
+    response.on('end', () => {
+      const hasMeta = body.includes('<meta name="offline-ready" content="true"');
+      if (!hasMeta) {
+        console.error('La balise <meta name="offline-ready" content="true"> est absente.');
+        server.close(() => process.exit(1));
+        return;
+      }
+      console.log('Test réussi: index.html répond et contient la balise meta offline-ready.');
+      server.close(() => process.exit(0));
+    });
+  }).on('error', (error) => {
+    console.error('Erreur de requête HTTP:', error);
+    server.close(() => process.exit(1));
+  });
+});


### PR DESCRIPTION
## Summary
- refresh the global styling with a brighter Apple-inspired aesthetic, new sections, and enhanced animations
- drive every thematic page from a shared dataset, rendering timelines, checklists, insights, and procedural illustrations at runtime
- add the new content module to the cache list, update the manifest colors, and document how to customise the generated artwork and text

## Testing
- `node my-offline-site/test/check_site.js`


------
https://chatgpt.com/codex/tasks/task_e_68dbc753c8d4832b9267ef0c88a0829b